### PR TITLE
[Feature Request]: Xへの投稿に対してmentionを含むポストのmention→link変換

### DIFF
--- a/astro/src/components/Client/bsky/lib/saveTagList.ts
+++ b/astro/src/components/Client/bsky/lib/saveTagList.ts
@@ -1,12 +1,8 @@
 // service
-import { setSavedTags, readSavedTags } from "@/utils/useLocalStorage";
+import { setSavedTags, readSavedTags } from "@/utils/useLocalStorage"
 import { richTextFacetParser } from "@/utils/richTextParser"
 
-const saveTagToSavedTags = ({
-    postText
-}: {
-    postText: string
-}): void => {
+const saveTagToSavedTags = ({ postText }: { postText: string }): void => {
     // 保存できるタグの上限
     const maxTagCount = 8
 
@@ -16,8 +12,8 @@ const saveTagToSavedTags = ({
 
     const savedTag = readSavedTags()
 
-    let taglist: string[] = (savedTag !== null) ? savedTag : []
-    parseResult.forEach((value) => {
+    const taglist: string[] = savedTag !== null ? savedTag : []
+    parseResult.forEach(value => {
         const tagName = value
         const tagIndex = taglist.indexOf(tagName)
         if (tagIndex < 0) {

--- a/astro/src/components/Client/pagedb/ProfileCard.tsx
+++ b/astro/src/components/Client/pagedb/ProfileCard.tsx
@@ -1,23 +1,33 @@
 import { useContext } from "react"
 import { Profile_context } from "../common/contexts"
-import { link } from "../common/tailwindVariants";
+import { link } from "../common/tailwindVariants"
+import { bskyProfileURL } from "@/env/bsky"
 
 export const Component = () => {
     const { profile } = useContext(Profile_context)
 
     return (
         <>
-            <img src={profile ? profile.avatar : undefined} className="w-10 h-10 mr-2 inline-block rounded-full bg-sky-400" /> :
-            <span className="mx-1 text-wrap align-middle">{profile ? profile.displayName : ""}
+            <img
+                src={profile ? profile.avatar : undefined}
+                className="w-10 h-10 mr-2 inline-block rounded-full bg-sky-400"
+            />{" "}
+            :
+            <span className="mx-1 text-wrap align-middle">
+                {profile ? profile.displayName : ""}
                 {profile ? (
-                    <a href={new URL(profile.handle, "https://bsky.app/profile/").toString()}
-                        className={link({ class: "m-1" })}>
+                    <a
+                        href={new URL(
+                            profile.handle,
+                            bskyProfileURL,
+                        ).toString()}
+                        className={link({ class: "m-1" })}
+                    >
                         @{profile.handle}
                     </a>
                 ) : (
                     <></>
-                )
-                }
+                )}
             </span>
         </>
     )

--- a/astro/src/env/bsky.ts
+++ b/astro/src/env/bsky.ts
@@ -1,0 +1,1 @@
+export const bskyProfileURL = "https://bsky.app/profile/"

--- a/astro/src/utils/atproto_api/detectFacets.ts
+++ b/astro/src/utils/atproto_api/detectFacets.ts
@@ -4,21 +4,21 @@ import facets from "./facets"
 // 本家はinputは RichText型であるが、text型でなんとかする
 
 type regexResult = {
-    encoded: string,
+    encoded: string
     index: {
-        byteStart: number,
-        byteEnd: number,
+        byteStart: number
+        byteEnd: number
     }
 }
 const regexSeacrh = ({
     array,
     regex,
     encoded,
-    cursor = 0
+    cursor = 0,
 }: {
-    array: Array<regexResult>,
+    array: Array<regexResult>
     regex: RegExp
-    encoded: string,
+    encoded: string
     cursor?: number
 }) => {
     // 文字を取得するために使用
@@ -36,8 +36,8 @@ const regexSeacrh = ({
         encoded: linkref,
         index: {
             byteStart: cursor + regexedStart,
-            byteEnd: cursor + regexedEnd
-        }
+            byteEnd: cursor + regexedEnd,
+        },
     }
     array.push(Item)
     regexSeacrh({
@@ -51,25 +51,25 @@ const regexSeacrh = ({
 const createLinkFacet = ({
     encoded,
 }: {
-    encoded: string,
+    encoded: string
 }): Array<facets.link> => {
     const Regex = /(https?:\/\/[^ \r\n]+)( |\r\n|\n|\r)?/i
-    let result: Array<facets.link> = []
-    let regexResult: Array<regexResult> = []
+    const result: Array<facets.link> = []
+    const regexResult: Array<regexResult> = []
     regexSeacrh({
         array: regexResult,
         regex: Regex,
         encoded: encoded,
     })
-    for (let link of regexResult) {
+    for (const link of regexResult) {
         result.push({
             index: link.index,
             features: [
                 {
                     $type: "app.bsky.richtext.facet#link",
-                    uri: link.encoded
-                }
-            ]
+                    uri: link.encoded,
+                },
+            ],
         })
     }
     return result
@@ -78,74 +78,74 @@ const createLinkFacet = ({
 const createMentionFacet = async ({
     encoded,
 }: {
-    encoded: string,
+    encoded: string
 }): Promise<Array<facets.mention>> => {
-    const Regex = /(@[^ ]*) ?/i
-    let result: Array<facets.mention> = []
-    let regexResult: Array<regexResult> = []
+    const Regex = /(@[^\s\r\n]+)\s?/i
+    const result: Array<facets.mention> = []
+    const regexResult: Array<regexResult> = []
     regexSeacrh({
         array: regexResult,
         regex: Regex,
         encoded: encoded,
     })
-    for (let link of regexResult) {
-        const resResolve = await resolveHandle({ handle: link.encoded.slice(1) })
-        // 存在しないハンドルの場合はfacetから除外
-        if (typeof resResolve?.error !== "undefined") {
+    for (const link of regexResult) {
+        try {
+            const resResolve = await resolveHandle({
+                handle: link.encoded.slice(1),
+            })
+            result.push({
+                index: link.index,
+                features: [
+                    {
+                        $type: "app.bsky.richtext.facet#mention",
+                        did: resResolve.did,
+                    },
+                ],
+            })
+        } catch (e: unknown) {
             continue
         }
-        result.push({
-            index: link.index,
-            features: [
-                {
-                    $type: "app.bsky.richtext.facet#mention",
-                    did: resResolve.did
-                }
-            ]
-        })
     }
     return result
 }
 
-const createHashtagFacet = async ({
+const createHashtagFacet = ({
     encoded,
 }: {
-    encoded: string,
-}): Promise<Array<facets.hashtag>> => {
+    encoded: string
+}): Array<facets.hashtag> => {
     const Regex = /((#|#️⃣)[^ \r\n]*)( |\r\n|\n|\r)?/i
-    let result: Array<facets.hashtag> = []
-    let regexResult: Array<regexResult> = []
+    const result: Array<facets.hashtag> = []
+    const regexResult: Array<regexResult> = []
     regexSeacrh({
         array: regexResult,
         regex: Regex,
         encoded: encoded,
     })
-    for (let tag of regexResult) {
+    for (const tag of regexResult) {
         result.push({
             index: tag.index,
             features: [
                 {
                     $type: "app.bsky.richtext.facet#tag",
-                    tag: tag.encoded.slice(1)
-                }
-            ]
+                    tag: tag.encoded.slice(1),
+                },
+            ],
         })
     }
     return result
 }
 
 const detectFacets = async ({
-    text
+    text,
 }: {
     text: string
 }): Promise<Array<facets.link | facets.mention | facets.hashtag>> => {
-    let facets: Array<
-        facets.link | facets.mention | facets.hashtag
-    > = []
+    let facets: Array<facets.link | facets.mention | facets.hashtag> = []
     const encoded = encodeURI(text).replace(/%(20|0A)/g, " ")
     facets = facets.concat(createLinkFacet({ encoded }))
     facets = facets.concat(await createMentionFacet({ encoded }))
-    facets = facets.concat(await createHashtagFacet({ encoded }))
+    facets = facets.concat(createHashtagFacet({ encoded }))
     return facets
 }
 

--- a/astro/src/utils/atproto_api/resolveHandle.ts
+++ b/astro/src/utils/atproto_api/resolveHandle.ts
@@ -1,38 +1,33 @@
 import getEndpoint, { com_atproto } from "./base"
-import mtype from "./models/resolveHandle.json"
 import etype from "./models/error.json"
 const apiName = com_atproto.identity.resolveHandle
 const endpoint = getEndpoint(apiName)
 
+export type resolveHandleResult = {
+    did: string
+}
+
 export const api = async ({
-    handle
+    handle,
 }: {
-    handle: string,
-}): Promise<typeof mtype & typeof etype> => {
+    handle: string
+}): Promise<resolveHandleResult> => {
     const url = new URL(endpoint)
     url.searchParams.set("handle", handle)
-    return fetch(
-        url.toString(),
-        {
-            method: 'GET',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-        }).then(async (response) => {
-            if (!response?.ok) {
-                let res: typeof etype = await response.json()
-                let e: Error = new Error(res.message)
-                e.name = apiName
-                throw e
-            }
-            return await response.json()
+    return fetch(url.toString(), {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+        },
+    }).then<resolveHandleResult>(async response => {
+        if (!response?.ok) {
+            const res: typeof etype = (await response.json()) as typeof etype
+            const e: Error = new Error(res.message)
+            e.name = apiName
+            throw e
         }
-        ).catch((e: Error) => {
-            return {
-                error: e.name,
-                message: e.message
-            }
-        })
+        return (await response.json()) as resolveHandleResult
+    })
 }
 
 export default api


### PR DESCRIPTION
実装および修正
- `richTextParser`に致命的なバグがあったため修正しました
  -  `matchEnd`による`text`の切り取り範囲が過剰に広かったことが原因で、正常にテキストを処理できない場合がありました。
  - このコードの元になった`detectFacets.ts`は、この値はあくまでfacetsの作成にのみ用いており、テキストの切り取り・処理範囲に影響しなかったため、Bluesky側に影響が起きていませんでした。
- `atproto_api/resolveHandle.ts`におけるエラーハンドリングを改善しました。
  - これまでは本関数自体もatprotoの返り値に合わせて`{error,message}`を含むリスポンスを行っていましたが、この応答を作成するため、Typescriptの型として不適切な設定（正常リスポンスと異常リスポンスの交差型）を行っていました。
  - ESLintの指摘に対応するためこれをやめ、関数自体がErrorをthrowすることを正とするように変更しました。
    - そのため、今後は関数の呼び出し側にエラーハンドリングを委ねる形をとります。
  - この変更方針は、`atproto_api`配下のコードにも適応していきたいと考えています。
    - `atproto_api`のコード自体、公式クライアントへ置き換えたいと考えています: #15
- その他、関連箇所のコードに`npm run fix`をかけました。
  - 許容した方がいいかな、と考えている`@typescript-eslint/no-misused-promises`ルール以外のwarning/errorについては取り除きました。