### PR TITLE
[Improve code]: Linterの設定修正

### DIFF
--- a/astro/.eslintrc.cjs
+++ b/astro/.eslintrc.cjs
@@ -37,6 +37,14 @@ module.exports = {
                 ignoreRestSiblings: true,
             },
         ],
+        "@typescript-eslint/no-misused-promises": [
+            "warn",
+            {
+                checksVoidReturn: {
+                    attributes: false,
+                },
+            },
+        ],
     },
     ignorePatterns: [
         "dist",

--- a/astro/.eslintrc.cjs
+++ b/astro/.eslintrc.cjs
@@ -27,15 +27,23 @@ module.exports = {
         "@typescript-eslint/no-namespace": "warn",
         "@typescript-eslint/no-unused-vars": [
             "warn",
-            { destructuredArrayIgnorePattern: "^_" },
+            {
+                args: "all",
+                argsIgnorePattern: "^_",
+                caughtErrors: "all",
+                caughtErrorsIgnorePattern: "^_",
+                destructuredArrayIgnorePattern: "^_",
+                varsIgnorePattern: "^_",
+                ignoreRestSiblings: true,
+            },
         ],
     },
     ignorePatterns: [
-        "dist", 
-        "node_modules", 
+        "dist",
+        "node_modules",
         "tailwind.config.mjs",
         "jest.config.cjs",
-        "astro.config.mjs"
+        "astro.config.mjs",
     ],
     overrides: [
         {

--- a/astro/.eslintrc.cjs
+++ b/astro/.eslintrc.cjs
@@ -21,10 +21,6 @@ module.exports = {
         },
     },
     rules: {
-        indent: ["warn", 4, { SwitchCase: 1, MemberExpression: "off" }],
-        quotes: ["warn", "double"],
-        semi: ["warn", "never"],
-        "linebreak-style": ["warn", "unix"],
         "no-irregular-whitespace": "warn",
         "prefer-const": "warn",
         "@typescript-eslint/strict-boolean-expressions": "warn",


### PR DESCRIPTION
### 概要
このPRでは次の変更を行っています。

1. コーディングスタイルに関するルールを削除
2. 未使用の変数に関するルールを改善
3. JSXの属性に対するPromise型チェックのルールを無効化

### 修正後のリンティングエラー例

#### _(アンダースコア)から始まる変数の場合

```typescript
$("meta").each((_, element) => { ... })
```

```bash
$ npx astro check
...
15:00:11 [check] Getting diagnostics for Astro files in /workspaces/skyshare/astro...
Result (104 files): 
- 0 errors
- 0 warnings
- 0 hints

$ npx eslint src/pages/api/getOgpMeta.ts (出力なし)
```

#### 任意の変数の場合



```typescript
$("meta").each((unusedVar, element) => { ... })
```

```bash
$ npx astro check
...
15:01:16 [check] Getting diagnostics for Astro files in /workspaces/skyshare/astro...
src/pages/api/getOgpMeta.ts:143:21 - warning ts(6133): 'unusedVar' is declared but its value is never read.

143     $("meta").each((unusedVar, element) => { ... })
                        ~~~~~~~~~

Result (104 files): 
- 0 errors
- 0 warnings
- 1 hint

$ npx eslint src/pages/api/getOgpMeta.ts 

/workspaces/skyshare/astro/src/pages/api/getOgpMeta.ts
  143:21  warning  'unusedVar' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

✖ 1 problem (0 errors, 1 warning)
```

#### 別モジュールからインポートした変数の場合

```typescript
import { corsAllowOrigin, unusedImport} from "@/lib/vars"
```
```bash
$ npx astro check
...
src/pages/api/getOgpMeta.ts:3:27 - warning ts(6133): 'unusedImport' is declared but its value is never read.

3 import { corsAllowOrigin, unusedImport} from "@/lib/vars"
                            ~~~~~~~~~~~~

Result (104 files): 
- 0 errors
- 0 warnings
- 1 hint

$ npx eslint src/pages/api/getOgpMeta.ts 

/workspaces/skyshare/astro/src/pages/api/getOgpMeta.ts
  3:27  warning  'unusedImport' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars

✖ 1 problem (0 errors, 1 warning)
```

Resolves #64 