### PR TITLE
[Improve code]: astro/src/components/Client/bsky/* 手動formatter・Linter対応

### DIFF
--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -41,15 +41,14 @@ export const Component = ({
                 identifier: id,
                 password: pw,
             })
-            if ("error" in res && typeof res.error != "undefined") {
+            if ("error" in res) {
                 const e: Error = new Error(res.message)
                 e.name = res.error
                 throw e
             } else {
-                const successResponse = res as typeof dummyCreateSessionObject
-                setSession(successResponse)
+                setSession(res)
                 // セッションをlocalstorageへ保存
-                writeJwt(successResponse.refreshJwt)
+                writeJwt(res.refreshJwt)
                 setMsgInfo({
                     msg: "セッションを開始しました!",
                     isError: false,
@@ -63,7 +62,7 @@ export const Component = ({
                 }
                 // プロフィールを読み込み
                 await loadProfile({
-                    session: successResponse,
+                    session: res,
                     setProfile: setProfile,
                 })
             }

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -136,7 +136,7 @@ export const Component = ({
                             （BskyLinXに限らず）非公式のアプリを使う際はAppPasswordの利用が推奨されています。
                             <a className={link()}
                                 target="_blank"
-                                href="https://bsky.app/settings/app-passwords">
+                                href="https://bsky.app/settings/app-passwords" rel="noopener noreferrer">
                                 <b>bsky.appの⚙設定</b>→<b>🔒高度な設定(新規タブが開きます)</b>
                             </a>から生成してください。
                         </div>

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useContext, Dispatch, SetStateAction } from "react"
+import {
+    useState,
+    useEffect,
+    useContext,
+    Dispatch,
+    SetStateAction,
+} from "react"
 import { inputtext_base, link } from "../common/tailwindVariants"
 import { Session_context, Profile_context } from "../common/contexts"
 import { type msgInfo } from "../common/types"
@@ -9,12 +15,12 @@ import loadProfile from "./lib/loadProfile"
 import ProcButton from "../common/ProcButton"
 import Tooltip from "../common/Tooltip"
 import SavePasswordToggle from "./optionToggles/SavePasswordToggle"
-import {writeJwt, readLogininfo, setLogininfo } from "@/utils/useLocalStorage"
+import { writeJwt, readLogininfo, setLogininfo } from "@/utils/useLocalStorage"
 
 export const Component = ({
     setMsgInfo,
 }: {
-    setMsgInfo: Dispatch<SetStateAction<msgInfo>>,
+    setMsgInfo: Dispatch<SetStateAction<msgInfo>>
 }) => {
     const [loading, setLoad] = useState<boolean>(false)
     const [savePassword, setSavePassword] = useState<boolean>(false)
@@ -32,7 +38,7 @@ export const Component = ({
             }
             const res = await createSession({
                 identifier: id,
-                password: pw
+                password: pw,
             })
             if ("error" in res && typeof res.error != "undefined") {
                 const e: Error = new Error(res.message)
@@ -51,13 +57,13 @@ export const Component = ({
                 if (savePassword === true) {
                     setLogininfo({
                         id: identifier,
-                        pw: password
+                        pw: password,
                     })
                 }
                 // プロフィールを読み込み
                 await loadProfile({
                     session: successResponse,
-                    setProfile: setProfile
+                    setProfile: setProfile,
                 })
             }
         } catch (error: unknown) {
@@ -67,7 +73,7 @@ export const Component = ({
             }
             setMsgInfo({
                 msg: msg,
-                isError: true
+                isError: true,
             })
         }
         setLoad(false)
@@ -79,9 +85,7 @@ export const Component = ({
                 msg: "ブラウザに保存されたID/APWでログイン中...",
                 isError: false,
             })
-            await handleLogin(
-                loginInfo.id,
-                loginInfo.pw)
+            await handleLogin(loginInfo.id, loginInfo.pw)
         }
     }
     useEffect(() => {
@@ -89,66 +93,83 @@ export const Component = ({
     }, [])
 
     return (
-        <>
+        <div>
             <div className="mt-16">
                 <div className="align-middle mb-0">
                     <label className="w-32 inline-block my-auto">
                         Email or ID:
                     </label>
-                    <input onChange={(event) => setIdentifier(event.target.value)}
+                    <input
+                        onChange={event => setIdentifier(event.target.value)}
                         placeholder="example.bsky.social"
                         disabled={loading}
                         className={inputtext_base({
                             class: "max-w-52 w-full px-2",
                             kind: "outbound",
-                            disabled: loading
-                        })} type="text" />
+                            disabled: loading,
+                        })}
+                        type="text"
+                    />
                 </div>
                 <div className="align-middle">
                     <label className="w-32 inline-block my-auto">
                         AppPassword※:
                     </label>
-                    <input onChange={(event) => setPassword(event.target.value)}
+                    <input
+                        onChange={event => setPassword(event.target.value)}
                         placeholder="this-isex-ampl-epwd"
                         disabled={loading}
                         className={inputtext_base({
                             class: "max-w-52 w-full px-2",
                             kind: "outbound",
-                            disabled: loading
-                        })} type="password" />
+                            disabled: loading,
+                        })}
+                        type="password"
+                    />
                 </div>
                 <div className="my-2">
                     <ProcButton
                         handler={handleLogin}
                         isProcessing={loading}
                         context="Blueskyアカウントへログイン"
-                        disabled={!(identifier.length > 0 && password.length > 0)}
-                        showAnimation={true} />
+                        disabled={
+                            !(identifier.length > 0 && password.length > 0)
+                        }
+                        showAnimation={true}
+                    />
                 </div>
                 <div className="mx-auto w-fit">
                     <SavePasswordToggle
                         labeltext={"ID/AppPasswordをブラウザへ保存する"}
                         prop={savePassword}
-                        setProp={setSavePassword} />
+                        setProp={setSavePassword}
+                    />
                 </div>
-                <Tooltip tooltip={
-                    <div className="flex flex-col sm:flex-row">
-                        <div className="inline-block px-4 py-2 text-left">
-                            （BskyLinXに限らず）非公式のアプリを使う際はAppPasswordの利用が推奨されています。
-                            <a className={link()}
-                                target="_blank"
-                                href="https://bsky.app/settings/app-passwords" rel="noopener noreferrer">
-                                <b>bsky.appの⚙設定</b>→<b>🔒高度な設定(新規タブが開きます)</b>
-                            </a>から生成してください。
+                <Tooltip
+                    tooltip={
+                        <div className="flex flex-col sm:flex-row">
+                            <div className="inline-block px-4 py-2 text-left">
+                                （BskyLinXに限らず）非公式のアプリを使う際はAppPasswordの利用が推奨されています。
+                                <a
+                                    className={link()}
+                                    target="_blank"
+                                    href="https://bsky.app/settings/app-passwords"
+                                    rel="noopener noreferrer"
+                                >
+                                    <b>bsky.appの⚙設定</b>→
+                                    <b>🔒高度な設定(新規タブが開きます)</b>
+                                </a>
+                                から生成してください。
+                            </div>
                         </div>
-                    </div>
-                }>
+                    }
+                >
                     <span className="text-sky-400">
                         ※AppPasswordとは？(タップで説明を表示)
                     </span>
                 </Tooltip>
             </div>
-        </>
+        </div>
     )
 }
 

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -18,7 +18,7 @@ export const Component = ({
 }) => {
     const [loading, setLoad] = useState<boolean>(false)
     const [savePassword, setSavePassword] = useState<boolean>(false)
-    const [identifier, setIdentifer] = useState<string>("")
+    const [identifier, setIdentifier] = useState<string>("")
     const [password, setPassword] = useState<string>("")
     const { setSession } = useContext(Session_context)
     const { setProfile } = useContext(Profile_context)
@@ -95,7 +95,7 @@ export const Component = ({
                     <label className="w-32 inline-block my-auto">
                         Email or ID:
                     </label>
-                    <input onChange={(event) => setIdentifer(event.target.value)}
+                    <input onChange={(event) => setIdentifier(event.target.value)}
                         placeholder="example.bsky.social"
                         disabled={loading}
                         className={inputtext_base({

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -35,7 +35,7 @@ export const Component = ({
                 password: pw
             })
             if (typeof res.error !== "undefined") {
-                let e: Error = new Error(res.message)
+                const e: Error = new Error(res.message)
                 e.name = res.error
                 throw e
             } else {

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -2,14 +2,14 @@ import { useState, useEffect, useContext, Dispatch, SetStateAction } from "react
 import { inputtext_base, link } from "../common/tailwindVariants"
 import { Session_context, Profile_context } from "../common/contexts"
 import { type msgInfo } from "../common/types"
-import createSession from "@/utils/atproto_api/createSession";
-import loadProfile from "./lib/loadProfile";
+import createSession from "@/utils/atproto_api/createSession"
+import dummyCreateSessionObject from "@/utils/atproto_api/models/createSession.json"
+import loadProfile from "./lib/loadProfile"
 
-import { writeJwt } from "@/utils/useLocalStorage"
 import ProcButton from "../common/ProcButton"
 import Tooltip from "../common/Tooltip"
 import SavePasswordToggle from "./optionToggles/SavePasswordToggle"
-import { readLogininfo, setLogininfo } from "@/utils/useLocalStorage"
+import {writeJwt, readLogininfo, setLogininfo } from "@/utils/useLocalStorage"
 
 export const Component = ({
     setMsgInfo,
@@ -34,14 +34,15 @@ export const Component = ({
                 identifier: id,
                 password: pw
             })
-            if (typeof res.error !== "undefined") {
+            if ("error" in res && typeof res.error != "undefined") {
                 const e: Error = new Error(res.message)
                 e.name = res.error
                 throw e
             } else {
-                setSession(res)
+                const successResponse = res as typeof dummyCreateSessionObject
+                setSession(successResponse)
                 // セッションをlocalstorageへ保存
-                writeJwt(res.refreshJwt)
+                writeJwt(successResponse.refreshJwt)
                 setMsgInfo({
                     msg: "セッションを開始しました!",
                     isError: false,
@@ -55,7 +56,7 @@ export const Component = ({
                 }
                 // プロフィールを読み込み
                 await loadProfile({
-                    session: res,
+                    session: successResponse,
                     setProfile: setProfile
                 })
             }

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -16,6 +16,7 @@ import ProcButton from "../common/ProcButton"
 import Tooltip from "../common/Tooltip"
 import SavePasswordToggle from "./optionToggles/SavePasswordToggle"
 import { writeJwt, readLogininfo, setLogininfo } from "@/utils/useLocalStorage"
+import { servicename } from "@/env/vars"
 
 export const Component = ({
     setMsgInfo,
@@ -149,7 +150,7 @@ export const Component = ({
                     tooltip={
                         <div className="flex flex-col sm:flex-row">
                             <div className="inline-block px-4 py-2 text-left">
-                                （BskyLinXに限らず）非公式のアプリを使う際はAppPasswordの利用が推奨されています。
+                                {`（${servicename}に限らず）非公式のアプリを使う際はAppPasswordの利用が推奨されています。`}
                                 <a
                                     className={link()}
                                     target="_blank"

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -85,7 +85,7 @@ export const Component = ({
         }
     }
     useEffect(() => {
-        handleOnLoad()
+        void handleOnLoad()
     }, [])
 
     return (

--- a/astro/src/components/Client/bsky/LoginForm.tsx
+++ b/astro/src/components/Client/bsky/LoginForm.tsx
@@ -9,7 +9,6 @@ import { inputtext_base, link } from "../common/tailwindVariants"
 import { Session_context, Profile_context } from "../common/contexts"
 import { type msgInfo } from "../common/types"
 import createSession from "@/utils/atproto_api/createSession"
-import dummyCreateSessionObject from "@/utils/atproto_api/models/createSession.json"
 import loadProfile from "./lib/loadProfile"
 
 import ProcButton from "../common/ProcButton"

--- a/astro/src/components/Client/bsky/MediaPreview/AltDialog.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/AltDialog.tsx
@@ -1,5 +1,5 @@
 // utils
-import React, { memo, useRef, useCallback, useState, useEffect } from "react";
+import React, { memo, useRef, useCallback, useState, useEffect } from "react"
 
 // component
 import OverlayDialog from "../../common/OverlayDialog"
@@ -9,7 +9,7 @@ import { inputtext_base, link } from "../../common/tailwindVariants"
 import { MediaData } from "../../common/types"
 
 const Img = ({
-    mediaDataItem
+    mediaDataItem,
 }: {
     mediaDataItem: {
         alt: string
@@ -17,16 +17,19 @@ const Img = ({
     }
 }) => {
     return (
-        <img src={URL.createObjectURL(mediaDataItem.blob)} className="max-w-md w-full mx-auto" />
+        <img
+            src={URL.createObjectURL(mediaDataItem.blob)}
+            className="max-w-md w-full mx-auto"
+        />
     )
 }
 const MemoImg = memo(Img)
 
 export const Component = ({
     itemId,
-    mediaData
+    mediaData,
 }: {
-    itemId: number,
+    itemId: number
     mediaData: MediaData
 }) => {
     // mediaDataがimageではない場合はコンポーネントを無効に
@@ -34,7 +37,7 @@ export const Component = ({
         return
     }
     let mediaDataItem = mediaData.images[itemId]
-    const textref = useRef<HTMLTextAreaElement | null>(null);
+    const textref = useRef<HTMLTextAreaElement | null>(null)
     const [altBoxText, setAltBoxText] = useState<string>(mediaDataItem.alt)
     const maxShowAltLength = 10
 
@@ -42,17 +45,18 @@ export const Component = ({
         if (textref.current) {
             textref.current.value = mediaDataItem.alt
         }
-    };
+    }
 
     const handleCloseDialog = () => {
         mediaDataItem.alt = altBoxText
-    };
+    }
 
     const handleClickInDialog = useCallback(
         (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-            e.stopPropagation();
-        }, []
-    );
+            e.stopPropagation()
+        },
+        [],
+    )
 
     const handleOnChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
         // メディアがimagesの場合のみ処理
@@ -81,43 +85,51 @@ export const Component = ({
             callbackOpenDialog={handleOpenDialog}
             callbackCloseDialog={handleCloseDialog}
             buttonOption={{
-                className: [
-                    "rounded-lg", "border-1",
-                    "bg-opacity-70", "px-2",
-                    "bg-black", "border-white",
-                    "text-white", "absolute",
-                    "left-1", "bottom-1"].join(" ") + (
-                        altBoxText !== "" ? (" bg-blue-500") : ("")
-                    ),
+                className:
+                    [
+                        "rounded-lg",
+                        "border-1",
+                        "bg-opacity-70",
+                        "px-2",
+                        "bg-black",
+                        "border-white",
+                        "text-white",
+                        "absolute",
+                        "left-1",
+                        "bottom-1",
+                    ].join(" ") + (altBoxText !== "" ? " bg-blue-500" : ""),
                 content:
-                    altBoxText !== "" ? (
-                        `${altBoxText.slice(0, maxShowAltLength)
-                        }${altBoxText.length >= maxShowAltLength
-                            ? ("...") : ("")}`
-                    ) : (
-                        "Altを設定"
-                    )
-            }}>
-            <div onClick={handleClickInDialog} >
-                <MemoImg
-                    mediaDataItem={mediaDataItem} />
-                <label>画像に設定するAltを入力（ダイアログを閉じると反映）</label>
-                <textarea onChange={handleOnChange}
+                    altBoxText !== ""
+                        ? `${altBoxText.slice(0, maxShowAltLength)}${
+                              altBoxText.length >= maxShowAltLength ? "..." : ""
+                          }`
+                        : "Altを設定",
+            }}
+        >
+            <div onClick={handleClickInDialog}>
+                <MemoImg mediaDataItem={mediaDataItem} />
+                <label>
+                    画像に設定するAltを入力（ダイアログを閉じると反映）
+                </label>
+                <textarea
+                    onChange={handleOnChange}
                     autoFocus={true}
                     ref={textref}
                     placeholder="上記に設定するAltを入力してください"
                     className={inputtext_base({
                         kind: "outbound",
-                        class: "p-4 w-full md:w-lg resize-y overflow-y-auto h-32"
+                        class: "p-4 w-full md:w-lg resize-y overflow-y-auto h-32",
                     })}
                 />
                 <button
                     className={link({ enabled: !(altBoxText === "") })}
                     disabled={altBoxText === ""}
                     onClick={handleClick}
-                >内容をクリア</button>
+                >
+                    内容をクリア
+                </button>
             </div>
         </OverlayDialog>
-    );
-};
+    )
+}
 export default Component

--- a/astro/src/components/Client/bsky/MediaPreview/DeleteItemButton.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/DeleteItemButton.tsx
@@ -30,7 +30,7 @@ const Component = ({
                 return
             }
             // Listから自身のitemIdを取り除き、これをリストに追加する
-            let result = mediaData.images.filter(
+            const result = mediaData.images.filter(
                 (_, index) => index !== itemId
             )
             // 全てのメディアが削除された場合は null とする

--- a/astro/src/components/Client/bsky/MediaPreview/DeleteItemButton.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/DeleteItemButton.tsx
@@ -7,10 +7,10 @@ import { MediaData } from "../../common/types"
 const Component = ({
     itemId,
     mediaData,
-    setMediaData
+    setMediaData,
 }: {
-    itemId: number,
-    mediaData: MediaData,
+    itemId: number
+    mediaData: MediaData
     setMediaData: Dispatch<SetStateAction<MediaData>>
 }) => {
     const handleClick = () => {
@@ -31,7 +31,7 @@ const Component = ({
             }
             // Listから自身のitemIdを取り除き、これをリストに追加する
             const result = mediaData.images.filter(
-                (_, index) => index !== itemId
+                (_, index) => index !== itemId,
             )
             // 全てのメディアが削除された場合は null とする
             if (result.length <= 0) {
@@ -40,7 +40,7 @@ const Component = ({
             }
             setMediaData({
                 type: mediaData.type,
-                images: result
+                images: result,
             })
         }
     }
@@ -50,14 +50,16 @@ const Component = ({
                 onClick={handleClick}
                 className={[
                     "rounded-full",
-                    "h-8", "w-8",
+                    "h-8",
+                    "w-8",
                     "border-2",
                     "bg-white",
                     "border-gray-700",
                     "absolute",
                     "left-1",
                     "top-1",
-                ].join(" ")}>
+                ].join(" ")}
+            >
                 ✖️
             </button>
         </>

--- a/astro/src/components/Client/bsky/MediaPreview/MetaView.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/MetaView.tsx
@@ -1,34 +1,43 @@
 // service
 import { MediaData } from "../../common/types"
 
-export const Component = ({
-    mediaData
-}: {
-    mediaData: MediaData
-}) => {
+export const Component = ({ mediaData }: { mediaData: MediaData }) => {
     // mediaDataがimageではない場合はコンポーネントを無効に
     if (mediaData === null || mediaData.type !== "external") {
         return
     }
     const mediaDataItem = mediaData.meta
     return (
-        <div className={[
-            "rounded-2xl", "border-2",
-            "bg-opacity-90", "p-2",
-            "bg-white", "border-gray-200",
-            "text-black", "block",
-            "left-0", "bottom-0",
-            "w-full", "m-0"
-        ].join(" ")}>
+        <div
+            className={[
+                "rounded-2xl",
+                "border-2",
+                "bg-opacity-90",
+                "p-2",
+                "bg-white",
+                "border-gray-200",
+                "text-black",
+                "block",
+                "left-0",
+                "bottom-0",
+                "w-full",
+                "m-0",
+            ].join(" ")}
+        >
             <div className={["text-left", "m-0"].join(" ")}>
                 {mediaDataItem.title}
             </div>
-            <div className={[
-                "text-left", "m-0", "text-xs",
-                "text-gray-600"].join(" ")}>
+            <div
+                className={[
+                    "text-left",
+                    "m-0",
+                    "text-xs",
+                    "text-gray-600",
+                ].join(" ")}
+            >
                 {mediaDataItem.description}
             </div>
         </div>
-    );
-};
+    )
+}
 export default Component

--- a/astro/src/components/Client/bsky/MediaPreview/MetaView.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/MetaView.tsx
@@ -10,7 +10,7 @@ export const Component = ({
     if (mediaData === null || mediaData.type !== "external") {
         return
     }
-    let mediaDataItem = mediaData.meta
+    const mediaDataItem = mediaData.meta
     return (
         <div className={[
             "rounded-2xl", "border-2",

--- a/astro/src/components/Client/bsky/buttons/AddImageButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/AddImageButton.tsx
@@ -14,14 +14,16 @@ import pic from "@/images/image.svg"
 const Component = ({
     disabled,
     mediaData,
-    setMediaData
+    setMediaData,
 }: {
     disabled: boolean
-    mediaData: MediaData,
+    mediaData: MediaData
     setMediaData: Dispatch<SetStateAction<MediaData>>
 }) => {
-    const inputRef = useRef<HTMLInputElement>(null!);
-    const handleClick = () => { inputRef.current.click() }
+    const inputRef = useRef<HTMLInputElement>(null!)
+    const handleClick = () => {
+        inputRef.current.click()
+    }
 
     /**
      * ファイル選択時の処理を行います
@@ -42,23 +44,32 @@ const Component = ({
     const acceptlist = imageExtensions.join(",")
     return (
         <>
-            <input type="file" accept={acceptlist}
+            <input
+                type="file"
+                accept={acceptlist}
                 ref={inputRef}
                 style={{ display: "none" }}
                 onChange={handleFilechanged}
-                multiple />
+                multiple
+            />
             <ProcButton
                 handler={handleClick}
                 isProcessing={disabled}
                 className={["py-0"]}
                 context={
-                    <img src={pic.src}
+                    <img
+                        src={pic.src}
                         className={[
-                            "w-7", "h-7", "p-0.5",
-                            "inline-block", "align-middle"
+                            "w-7",
+                            "h-7",
+                            "p-0.5",
+                            "inline-block",
+                            "align-middle",
                         ].join(" ")}
-                    />}
-                showAnimation={false} />
+                    />
+                }
+                showAnimation={false}
+            />
         </>
     )
 }

--- a/astro/src/components/Client/bsky/buttons/DraftSaveButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/DraftSaveButton.tsx
@@ -46,7 +46,7 @@ export const Component = ({
 
         saveTagToSavedTags({ postText })
 
-        const newDrafts = [postText, ...readDrafts() || []]
+        const newDrafts = [postText, ...readDrafts()]
 
         saveDrafts(newDrafts)
         setDrafts(newDrafts)

--- a/astro/src/components/Client/bsky/buttons/DraftSaveButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/DraftSaveButton.tsx
@@ -32,7 +32,7 @@ export const Component = ({
 
     const handleSavePost = () => {
         const isValidPost = (): boolean => {
-            let result: boolean = postText.length >= 1
+            const result: boolean = postText.length >= 1
             return result
         }
 

--- a/astro/src/components/Client/bsky/buttons/DraftSaveButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/DraftSaveButton.tsx
@@ -5,30 +5,28 @@ import { Dispatch, SetStateAction } from "react"
 import ProcButton from "../../common/ProcButton"
 
 // service
-import { saveDrafts, readDrafts } from "@/utils/useLocalStorage";
+import { saveDrafts, readDrafts } from "@/utils/useLocalStorage"
 import { msgInfo } from "../../common/types"
-import saveTagToSavedTags from "../lib/saveTagList";
+import saveTagToSavedTags from "../lib/saveTagList"
 
 export const Component = ({
     postText,
     setPostText,
     setDrafts,
     setMsgInfo,
-    className = []
+    className = [],
 }: {
-    postText: string,
-    setPostText: Dispatch<SetStateAction<string>>,
-    setDrafts: Dispatch<SetStateAction<Array<string>>>,
-    setMsgInfo: Dispatch<SetStateAction<msgInfo>>,
+    postText: string
+    setPostText: Dispatch<SetStateAction<string>>
+    setDrafts: Dispatch<SetStateAction<Array<string>>>
+    setMsgInfo: Dispatch<SetStateAction<msgInfo>>
     className?: Array<string>
 }) => {
-
     /**
      * 下書きとして保存可能かどうかを判定します
      * @returns ポスト可能な場合true
      */
     const isValidDraft = () => postText.length >= 1
-
 
     const handleSavePost = () => {
         const isValidPost = (): boolean => {
@@ -39,7 +37,7 @@ export const Component = ({
         if (!isValidPost()) {
             setMsgInfo({
                 msg: "ポスト本文が存在しません。",
-                isError: true
+                isError: true,
             })
             return
         }
@@ -54,7 +52,7 @@ export const Component = ({
 
         setMsgInfo({
             msg: "下書きを保存しました。",
-            isError: false
+            isError: false,
         })
     }
 
@@ -63,13 +61,12 @@ export const Component = ({
             buttonID="post"
             handler={handleSavePost}
             isProcessing={false}
-            context={<span className={[
-                "my-auto"
-            ].join(" ")}>
-                下書きを保存
-            </span>}
+            context={
+                <span className={["my-auto"].join(" ")}>下書きを保存</span>
+            }
             className={["my-0", "py-0.5", "align-middle"].concat(className)}
-            disabled={!isValidDraft()} />
+            disabled={!isValidDraft()}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/bsky/buttons/LogoutButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/LogoutButton.tsx
@@ -5,24 +5,24 @@ import { useState, useContext, Dispatch, SetStateAction } from "react"
 import ProcButton from "../../common/ProcButton"
 
 // atproto
-import deleteSession from "@/utils/atproto_api/deleteSession";
+import deleteSession from "@/utils/atproto_api/deleteSession"
 
 // service
 import { Session_context } from "../../common/contexts"
 import { type msgInfo } from "../../common/types"
-import { resetJwt, resetLoginInfo } from "@/utils/useLocalStorage";
+import { resetJwt, resetLoginInfo } from "@/utils/useLocalStorage"
 
 export const Component = ({
     className,
     setMsgInfo,
     reload,
     isProcessing,
-    setProcessing
+    setProcessing,
 }: {
-    className?: Array<string>,
-    setMsgInfo?: Dispatch<SetStateAction<msgInfo>>,
+    className?: Array<string>
+    setMsgInfo?: Dispatch<SetStateAction<msgInfo>>
     reload: boolean
-    isProcessing: boolean,
+    isProcessing: boolean
     setProcessing: Dispatch<SetStateAction<boolean>>
 }) => {
     const { session, setSession } = useContext(Session_context)
@@ -43,7 +43,7 @@ export const Component = ({
                 handle: null,
             })
             await deleteSession({
-                refreshJwt: session.refreshJwt
+                refreshJwt: session.refreshJwt,
             })
             if (setMsgInfo !== undefined) {
                 setMsgInfo({
@@ -53,13 +53,13 @@ export const Component = ({
             }
         } catch (error: unknown) {
             let msg: string = "Unexpected Unknown Error"
-            if(error instanceof Error) {
+            if (error instanceof Error) {
                 msg = error.name + ": " + error.message
             }
             if (setMsgInfo !== undefined) {
                 setMsgInfo({
                     msg: msg,
-                    isError: true
+                    isError: true,
                 })
             }
         }
@@ -76,7 +76,8 @@ export const Component = ({
             isProcessing={isProcessing}
             context="ログアウト"
             showAnimation={loading}
-            className={className} />
+            className={className}
+        />
     )
 }
 

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -214,20 +214,21 @@ export const Component = ({
                     )
                 })
                 // uploadBlobを並列処理し、その結果を格納する
-                const resultUploadBlob: uploadBlobResult[] = await Promise.all(uploadBlobTasks).then(
-                    values => {
+                const resultUploadBlob: uploadBlobResult[] = await Promise.all(
+                    uploadBlobTasks,
+                ).then(values => {
                     return values
-                    },
-                )
-                // Blobのアップロードに失敗したファイルが一つでも存在した場合停止する
-                const resultUploadBlobSuccess: uploadBlobSuccessResult[] = resultUploadBlob.map(value => {
-                    if ("error" in value) {
-                        const e: Error = new Error(value.message)
-                        e.name = value.error
-                        throw e
-                    }
-                    return value
                 })
+                // Blobのアップロードに失敗したファイルが一つでも存在した場合停止する
+                const resultUploadBlobSuccess: uploadBlobSuccessResult[] =
+                    resultUploadBlob.map(value => {
+                        if ("error" in value) {
+                            const e: Error = new Error(value.message)
+                            e.name = value.error
+                            throw e
+                        }
+                        return value
+                    })
 
                 // Recordの作成
                 switch (mediaData.type) {
@@ -284,9 +285,7 @@ export const Component = ({
                 accessJwt: session.accessJwt,
                 record: Record,
             })
-            if (
-                "error" in createRecordResult
-            ) {
+            if ("error" in createRecordResult) {
                 const e: Error = new Error(createRecordResult.message)
                 e.name = createRecordResult.error
                 throw e
@@ -307,8 +306,7 @@ export const Component = ({
                 })
                 const createPageResult = await createPage({
                     accessJwt: session.accessJwt,
-                    uri: createRecordResult
-                        .uri,
+                    uri: createRecordResult.uri,
                 })
                 if (typeof createPageResult?.error !== "undefined") {
                     const e: Error = new Error(createPageResult.message)

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -21,8 +21,6 @@ import resolveHandle, {
     type resolveHandleResult,
 } from "@/utils/atproto_api/resolveHandle"
 
-import dummyCreateRecordObject from "@/utils/atproto_api/models/createRecord.json"
-
 // backend api
 import createPage from "@/lib/pagedbAPI/createPage"
 import browserImageCompression from "@/utils/browserImageCompression"

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -117,9 +117,9 @@ export const Component = ({
                 labels:
                     selfLabel !== null
                         ? {
-                            $type: "com.atproto.label.defs#selfLabels",
-                            values: [selfLabel],
-                        }
+                              $type: "com.atproto.label.defs#selfLabels",
+                              values: [selfLabel],
+                          }
                         : undefined,
                 via: options.appendVia !== false ? servicename : undefined,
                 facets: facets.length > 0 ? facets : undefined,
@@ -232,7 +232,8 @@ export const Component = ({
                     }
                 })
 
-                const resultUploadBlobSuccess = resultUploadBlob as uploadBlobSuccessResult[]
+                const resultUploadBlobSuccess =
+                    resultUploadBlob as uploadBlobSuccessResult[]
 
                 // Recordの作成
                 switch (mediaData.type) {
@@ -241,12 +242,14 @@ export const Component = ({
                             ...Record,
                             embed: {
                                 $type: "app.bsky.embed.images",
-                                images: resultUploadBlobSuccess.map((value, index) => {
-                                    return {
-                                        image: value.blob,
-                                        alt: mediaData.images[index].alt,
-                                    }
-                                }),
+                                images: resultUploadBlobSuccess.map(
+                                    (value, index) => {
+                                        return {
+                                            image: value.blob,
+                                            alt: mediaData.images[index].alt,
+                                        }
+                                    },
+                                ),
                             },
                         }
                         break
@@ -258,7 +261,7 @@ export const Component = ({
                                 $type: "app.bsky.embed.external",
                                 external: {
                                     thumb:
-                                    resultUploadBlobSuccess.length >= 1
+                                        resultUploadBlobSuccess.length >= 1
                                             ? resultUploadBlobSuccess[0].blob
                                             : undefined,
                                     uri: mediaData.meta.url,
@@ -287,7 +290,10 @@ export const Component = ({
                 accessJwt: session.accessJwt,
                 record: Record,
             })
-            if ("error" in createRecordResult && typeof createRecordResult.error != "undefined") {
+            if (
+                "error" in createRecordResult &&
+                typeof createRecordResult.error != "undefined"
+            ) {
                 const e: Error = new Error(createRecordResult.message)
                 e.name = createRecordResult.error
                 throw e
@@ -308,7 +314,8 @@ export const Component = ({
                 })
                 const createPageResult = await createPage({
                     accessJwt: session.accessJwt,
-                    uri: (createRecordResult as typeof dummyCreateRecordObject).uri,
+                    uri: (createRecordResult as typeof dummyCreateRecordObject)
+                        .uri,
                 })
                 if (typeof createPageResult?.error !== "undefined") {
                     const e: Error = new Error(createPageResult.message)

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -223,7 +223,7 @@ export const Component = ({
                 )
                 // Blobのアップロードに失敗したファイルが一つでも存在した場合停止する
                 resultUploadBlob.forEach(value => {
-                    if ("error" in value && typeof value.error != "undefined") {
+                    if ("error" in value) {
                         const e: Error = new Error(value.message)
                         e.name = value.error
                         throw e

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -222,17 +222,14 @@ export const Component = ({
                     },
                 )
                 // Blobのアップロードに失敗したファイルが一つでも存在した場合停止する
-                resultUploadBlob.forEach(value => {
+                const resultUploadBlobSuccess: uploadBlobSuccessResult[] = resultUploadBlob.map(value => {
                     if ("error" in value) {
                         const e: Error = new Error(value.message)
                         e.name = value.error
                         throw e
                     }
+                    return value
                 })
-
-                // Blobのアップロード結果にエラーが含まれていない場合、すべて成功レスポンスとみなす
-                const resultUploadBlobSuccess =
-                    resultUploadBlob as uploadBlobSuccessResult[]
 
                 // Recordの作成
                 switch (mediaData.type) {

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -180,8 +180,6 @@ export const Component = ({
                 mediaData !== null &&
                 mediaData.images.length > 0 &&
                 mediaData.images[0].blob !== null
-            // uploadBlobを行なった場合は結果が格納される
-            let resultUploadBlob: Array<uploadBlobResult> = []
 
             // メディアデータが存在する場合はRecordに対して特定の処理を行う
             if (ImageAttached) {
@@ -217,8 +215,8 @@ export const Component = ({
                         }),
                     )
                 })
-                // uploadBlobを並列処理
-                resultUploadBlob = await Promise.all(uploadBlobTasks).then(
+                // uploadBlobを並列処理し、その結果を格納する
+                const resultUploadBlob: uploadBlobResult[] = await Promise.all(uploadBlobTasks).then(
                     values => {
                     return values
                     },

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -220,7 +220,7 @@ export const Component = ({
                 // uploadBlobを並列処理
                 resultUploadBlob = await Promise.all(uploadBlobTasks).then(
                     values => {
-                        return values
+                    return values
                     },
                 )
                 // Blobのアップロードに失敗したファイルが一つでも存在した場合停止する
@@ -292,8 +292,7 @@ export const Component = ({
                 record: Record,
             })
             if (
-                "error" in createRecordResult &&
-                typeof createRecordResult.error != "undefined"
+                "error" in createRecordResult
             ) {
                 const e: Error = new Error(createRecordResult.message)
                 e.name = createRecordResult.error
@@ -315,7 +314,7 @@ export const Component = ({
                 })
                 const createPageResult = await createPage({
                     accessJwt: session.accessJwt,
-                    uri: (createRecordResult as typeof dummyCreateRecordObject)
+                    uri: createRecordResult
                         .uri,
                 })
                 if (typeof createPageResult?.error !== "undefined") {

--- a/astro/src/components/Client/bsky/buttons/PostButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/PostButton.tsx
@@ -232,6 +232,7 @@ export const Component = ({
                     }
                 })
 
+                // Blobのアップロード結果にエラーが含まれていない場合、すべて成功レスポンスとみなす
                 const resultUploadBlobSuccess =
                     resultUploadBlob as uploadBlobSuccessResult[]
 

--- a/astro/src/components/Client/bsky/lib/addImageMediaData.ts
+++ b/astro/src/components/Client/bsky/lib/addImageMediaData.ts
@@ -23,27 +23,29 @@ const addImageMediaData = (
     // MediaData型は毎回typeにimagesを指定して定義しなおす
     const newMediaData: MediaData = {
         type: "images",
-        images: MediaData !== null && MediaData.type === "images" ? MediaData.images : []
+        images:
+            MediaData !== null && MediaData.type === "images"
+                ? MediaData.images
+                : [],
     }
     // MediaDataImagesを定義
-    const newMediaDataImages: Array<{ alt: string, blob: Blob }> = [
+    const newMediaDataImages: Array<{ alt: string; blob: Blob }> = [
         ...newMediaData.images,
-        ...(
-            Blobs.filter(
-                value => allowedMimeTypes.includes(value.type)
-            ).map((value) => {
+        ...Blobs.filter(value => allowedMimeTypes.includes(value.type)).map(
+            value => {
                 return {
                     alt: "",
                     blob: new Blob([value], {
-                        type: value.type
-                    })
+                        type: value.type,
+                    }),
                 }
-            }))
+            },
+        ),
     ]
     // 結合
     const result: MediaData = {
         type: "images",
-        images: newMediaDataImages.slice(0, maxAttachableImages)
+        images: newMediaDataImages.slice(0, maxAttachableImages),
     }
     setMediaData(result)
 }

--- a/astro/src/components/Client/bsky/lib/loadProfile.ts
+++ b/astro/src/components/Client/bsky/lib/loadProfile.ts
@@ -1,5 +1,5 @@
-import getProfile from "@/utils/atproto_api/getProfile";
-import type model_getProfile from "@/utils/atproto_api/models/getProfile.json";
+import getProfile from "@/utils/atproto_api/getProfile"
+import type model_getProfile from "@/utils/atproto_api/models/getProfile.json"
 import { Dispatch, SetStateAction } from "react"
 import etype from "@/utils/atproto_api/models/error.json"
 
@@ -8,10 +8,10 @@ export const loadProfile = async ({
     setProfile,
 }: {
     session: {
-        accessJwt: string,
+        accessJwt: string
         handle: string
-    },
-    setProfile: Dispatch<SetStateAction<typeof model_getProfile | null>>,
+    }
+    setProfile: Dispatch<SetStateAction<typeof model_getProfile | null>>
 }): Promise<void | typeof etype> => {
     try {
         setProfile(null)
@@ -20,16 +20,16 @@ export const loadProfile = async ({
         }
         const res = await getProfile({
             accessJwt: session.accessJwt,
-            handle: session.handle
+            handle: session.handle,
         })
         if (res != null && !("error" in res)) {
             setProfile(res)
         }
     } catch (e: unknown) {
-        if (e instanceof Error){
+        if (e instanceof Error) {
             return {
                 error: e.name,
-                message: e.message
+                message: e.message,
             }
         }
     }

--- a/astro/src/components/Client/bsky/lib/loadProfile.ts
+++ b/astro/src/components/Client/bsky/lib/loadProfile.ts
@@ -22,7 +22,7 @@ export const loadProfile = async ({
             accessJwt: session.accessJwt,
             handle: session.handle,
         })
-        if (res != null && !("error" in res)) {
+        if (!("error" in res)) {
             setProfile(res)
         }
     } catch (e: unknown) {

--- a/astro/src/components/Client/bsky/lib/loadProfile.ts
+++ b/astro/src/components/Client/bsky/lib/loadProfile.ts
@@ -22,9 +22,8 @@ export const loadProfile = async ({
             accessJwt: session.accessJwt,
             handle: session.handle
         })
-        if (res !== null && typeof res?.error === "undefined") {
-            const res_prof: typeof model_getProfile = res as typeof model_getProfile
-            setProfile(res_prof)
+        if (res != null && !("error" in res)) {
+            setProfile(res)
         }
     } catch (e: unknown) {
         if (e instanceof Error){

--- a/astro/src/components/Client/bsky/optionToggles/AppendViaToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/AppendViaToggle.tsx
@@ -10,10 +10,10 @@ import { readAppendVia, setAppendVia } from "@/utils/useLocalStorage"
 const Component = ({
     labeltext,
     prop,
-    setProp
+    setProp,
 }: {
-    labeltext: ReactNode,
-    prop: boolean,
+    labeltext: ReactNode
+    prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
 }) => {
     return (
@@ -22,7 +22,8 @@ const Component = ({
             setProp={setProp}
             initialValue={readAppendVia(false)}
             setPropConfig={setAppendVia}
-            labeltext={labeltext} />
+            labeltext={labeltext}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/bsky/optionToggles/AutoXPopupToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/AutoXPopupToggle.tsx
@@ -10,10 +10,10 @@ import { readAutoXPopup, setAutoXPopup } from "@/utils/useLocalStorage"
 const Component = ({
     labeltext,
     prop,
-    setProp
+    setProp,
 }: {
-    labeltext: ReactNode,
-    prop: boolean,
+    labeltext: ReactNode
+    prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
 }) => {
     return (
@@ -22,7 +22,8 @@ const Component = ({
             setProp={setProp}
             initialValue={readAutoXPopup(false)}
             setPropConfig={setAutoXPopup}
-            labeltext={labeltext} />
+            labeltext={labeltext}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/bsky/optionToggles/ForceIntentToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/ForceIntentToggle.tsx
@@ -10,10 +10,10 @@ import { readForceIntent, setForceIntent } from "@/utils/useLocalStorage"
 const Component = ({
     labeltext,
     prop,
-    setProp
+    setProp,
 }: {
-    labeltext: ReactNode,
-    prop: boolean,
+    labeltext: ReactNode
+    prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
 }) => {
     return (
@@ -22,7 +22,8 @@ const Component = ({
             setProp={setProp}
             initialValue={readForceIntent(false)}
             setPropConfig={setForceIntent}
-            labeltext={labeltext} />
+            labeltext={labeltext}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/bsky/optionToggles/NoGenerateToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/NoGenerateToggle.tsx
@@ -10,10 +10,10 @@ import { readNoGenerate, setNoGenerate } from "@/utils/useLocalStorage"
 const Component = ({
     labeltext,
     prop,
-    setProp
+    setProp,
 }: {
-    labeltext: ReactNode,
-    prop: boolean,
+    labeltext: ReactNode
+    prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
 }) => {
     return (
@@ -22,7 +22,8 @@ const Component = ({
             setProp={setProp}
             initialValue={readNoGenerate(false)}
             setPropConfig={setNoGenerate}
-            labeltext={labeltext} />
+            labeltext={labeltext}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/bsky/optionToggles/SavePasswordToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/SavePasswordToggle.tsx
@@ -10,10 +10,10 @@ import { readSavePassword, setSavePassword } from "@/utils/useLocalStorage"
 const Component = ({
     labeltext,
     prop,
-    setProp
+    setProp,
 }: {
-    labeltext: ReactNode,
-    prop: boolean,
+    labeltext: ReactNode
+    prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
 }) => {
     return (
@@ -22,7 +22,8 @@ const Component = ({
             setProp={setProp}
             initialValue={readSavePassword(false)}
             setPropConfig={setSavePassword}
-            labeltext={labeltext} />
+            labeltext={labeltext}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/bsky/optionToggles/ShowTaittsuuToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/ShowTaittsuuToggle.tsx
@@ -10,10 +10,10 @@ import { readShowTaittsuu, setShowTaittsuu } from "@/utils/useLocalStorage"
 const Component = ({
     labeltext,
     prop,
-    setProp
+    setProp,
 }: {
-    labeltext: ReactNode,
-    prop: boolean,
+    labeltext: ReactNode
+    prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
 }) => {
     return (
@@ -22,7 +22,8 @@ const Component = ({
             setProp={setProp}
             initialValue={readShowTaittsuu(false)}
             setPropConfig={setShowTaittsuu}
-            labeltext={labeltext} />
+            labeltext={labeltext}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/bsky/selectLists/LanguageSelectList.tsx
+++ b/astro/src/components/Client/bsky/selectLists/LanguageSelectList.tsx
@@ -1,32 +1,37 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react"
 import SelectList from "../../common/SelectList"
 const langList = [
     {
         label: "日本語",
-        code: "ja"
-    }, {
+        code: "ja",
+    },
+    {
         label: "English",
-        code: "en"
-    }, {
+        code: "en",
+    },
+    {
         label: "中文",
-        code: "zh"
-    }, {
+        code: "zh",
+    },
+    {
         label: "한국어",
-        code: "ko"
-    }];
+        code: "ko",
+    },
+]
 export const Component = ({
     disabled,
-    setLanguage
+    setLanguage,
 }: {
-    disabled: boolean,
-    setLanguage: Dispatch<SetStateAction<string>>,
+    disabled: boolean
+    setLanguage: Dispatch<SetStateAction<string>>
 }) => {
     return (
         <>
-            <SelectList 
+            <SelectList
                 setCode={setLanguage}
                 codeMap={langList}
-                disabled={disabled}/>
+                disabled={disabled}
+            />
         </>
     )
 }

--- a/astro/src/components/Client/bsky/selectLists/SelfLabelsSelectList.tsx
+++ b/astro/src/components/Client/bsky/selectLists/SelfLabelsSelectList.tsx
@@ -1,63 +1,73 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react"
 import SelectList from "../../common/SelectList"
 import { label } from "@/utils/atproto_api/labels"
 import pic from "@/images/warn.svg"
 
-const labellist: Array<{ label: string, code: label.value | null }> = [
+const labellist: Array<{ label: string; code: label.value | null }> = [
     {
         label: "-",
-        code: null
-    }, {
+        code: null,
+    },
+    {
         label: "きわどい",
         code: {
-            val: "sexual"
-        }
-    }, {
+            val: "sexual",
+        },
+    },
+    {
         label: "ヌード",
         code: {
-            val: "nudity"
-        }
-    }, {
+            val: "nudity",
+        },
+    },
+    {
         label: "ポルノ",
         code: {
-            val: "porn"
-        }
-    }, {
+            val: "porn",
+        },
+    },
+    {
         label: "ネタバレ",
         code: {
-            val: "spoiler"
-        }
-    }, {
+            val: "spoiler",
+        },
+    },
+    {
         label: "警告表示",
         code: {
-            val: "!warn"
-        }
-    }];
+            val: "!warn",
+        },
+    },
+]
 export const Component = ({
     disabled,
     setSelfLabel,
-    selectedLabel
+    selectedLabel,
 }: {
-    disabled: boolean,
-    setSelfLabel: Dispatch<SetStateAction<label.value | null>>,
+    disabled: boolean
+    setSelfLabel: Dispatch<SetStateAction<label.value | null>>
     selectedLabel: label.value | null
 }) => {
     return (
         <div className="flex my-auto mx-2">
-            <svg className={["w-6 h-6",
-                "p-0.5",
-                "inline-block",
-                "align-middle",
-                "my-auto",
-                "mr-1",
-                `${(selectedLabel !== null) ? "fill-sky-400" : "fill-gray-400" }`
-            ].join(" ")} >
+            <svg
+                className={[
+                    "w-6 h-6",
+                    "p-0.5",
+                    "inline-block",
+                    "align-middle",
+                    "my-auto",
+                    "mr-1",
+                    `${selectedLabel !== null ? "fill-sky-400" : "fill-gray-400"}`,
+                ].join(" ")}
+            >
                 <use xlinkHref={pic.src + "#warn"} height="100%" width="100%" />
             </svg>
             <SelectList
                 disabled={disabled}
                 setCode={setSelfLabel}
-                codeMap={labellist} />
+                codeMap={labellist}
+            />
         </div>
     )
 }

--- a/astro/src/components/Client/bsky/unique/DraftDialog.tsx
+++ b/astro/src/components/Client/bsky/unique/DraftDialog.tsx
@@ -5,19 +5,19 @@ import { Dispatch, SetStateAction, useEffect } from "react"
 import OverlayDialog from "../../common/OverlayDialog"
 
 // service
-import { readDrafts, saveDrafts } from "@/utils/useLocalStorage";
+import { readDrafts, saveDrafts } from "@/utils/useLocalStorage"
 
 export const Component = ({
     setPostText,
     drafts,
-    setDrafts
+    setDrafts,
 }: {
-    setPostText: Dispatch<SetStateAction<string>>,
-    drafts: Array<string>,
-    setDrafts: Dispatch<SetStateAction<Array<string>>>,
+    setPostText: Dispatch<SetStateAction<string>>
+    drafts: Array<string>
+    setDrafts: Dispatch<SetStateAction<Array<string>>>
 }) => {
     useEffect(() => {
-        setDrafts(readDrafts());
+        setDrafts(readDrafts())
     }, [])
 
     /**
@@ -58,55 +58,72 @@ export const Component = ({
         <OverlayDialog
             buttonOption={{
                 content: "下書き一覧",
-                className: ["mr-2"].join(" ")
-            }}>
-            <div className={[
-                "text-left",
-                "overflow-auto",
-                "max-h-dvh",
-                "px-2", "m-0",
-                "sm:min-w-96", "sm:max-w-screen-sm",
-                "min-w-48", "max-w-full"].join(" ")}>
-                <div className="border-gray-200 border-b-2">
-                    下書き一覧
-                </div>
-                {drafts.length > 0 ? drafts.map((draft, index) => (
-                    <div key={index} className={[
-                        "flex", "mb-0",
-                        "items-center",
-                        "py-4"].join(" ") + ` ${index !== drafts.length - 1 ? "border-b border-gray-200" : ""}`
-                    }>
-                        <div className={[
-                            "flex-1", "cursor-pointer",
-                            "line-clamp-1", "pr-4",
-                            "break-all", "mb-0"].join(" ")}
-                            onClick={() => {
-                                handleClickDraft(draft, index)
-                            }}>
-                            {draft.trim()}
+                className: ["mr-2"].join(" "),
+            }}
+        >
+            <div
+                className={[
+                    "text-left",
+                    "overflow-auto",
+                    "max-h-dvh",
+                    "px-2",
+                    "m-0",
+                    "sm:min-w-96",
+                    "sm:max-w-screen-sm",
+                    "min-w-48",
+                    "max-w-full",
+                ].join(" ")}
+            >
+                <div className="border-gray-200 border-b-2">下書き一覧</div>
+                {drafts.length > 0 ? (
+                    drafts.map((draft, index) => (
+                        <div
+                            key={index}
+                            className={
+                                ["flex", "mb-0", "items-center", "py-4"].join(
+                                    " ",
+                                ) +
+                                ` ${index !== drafts.length - 1 ? "border-b border-gray-200" : ""}`
+                            }
+                        >
+                            <div
+                                className={[
+                                    "flex-1",
+                                    "cursor-pointer",
+                                    "line-clamp-1",
+                                    "pr-4",
+                                    "break-all",
+                                    "mb-0",
+                                ].join(" ")}
+                                onClick={() => {
+                                    handleClickDraft(draft, index)
+                                }}
+                            >
+                                {draft.trim()}
+                            </div>
+                            <button
+                                className={[
+                                    "px-2 py-1",
+                                    "bg-red-500",
+                                    "text-white",
+                                    "rounded",
+                                    "hover:bg-red-600",
+                                    "focus:outline-none",
+                                    "focus:ring-2",
+                                    "focus:ring-red-500",
+                                    "focus:ring-opacity-50",
+                                ].join(" ")}
+                                onClick={() => {
+                                    handleDeleteDraft(index)
+                                }}
+                            >
+                                削除
+                            </button>
                         </div>
-                        <button
-                            className={[
-                                "px-2 py-1",
-                                "bg-red-500",
-                                "text-white",
-                                "rounded",
-                                "hover:bg-red-600",
-                                "focus:outline-none",
-                                "focus:ring-2",
-                                "focus:ring-red-500",
-                                "focus:ring-opacity-50"].join(" ")}
-                            onClick={() => {
-                                handleDeleteDraft(index)
-                            }}>
-                            削除
-                        </button>
-                    </div>
-                )) :
-                    <div>
-                        下書きがありません
-                    </div>
-                }
+                    ))
+                ) : (
+                    <div>下書きがありません</div>
+                )}
             </div>
         </OverlayDialog>
     )

--- a/astro/src/components/Client/bsky/unique/LoadSession.tsx
+++ b/astro/src/components/Client/bsky/unique/LoadSession.tsx
@@ -31,9 +31,7 @@ export const Component = ({
                 const refreshResult = await refreshSession({
                     refreshJwt: r_jwts,
                 })
-                if (
-                    "error" in refreshResult
-                ) {
+                if ("error" in refreshResult) {
                     resetJwt()
                     const e: Error = new Error(refreshResult.message)
                     e.name = refreshResult.error

--- a/astro/src/components/Client/bsky/unique/LoadSession.tsx
+++ b/astro/src/components/Client/bsky/unique/LoadSession.tsx
@@ -79,7 +79,7 @@ export const Component = ({
         setIsLoad(true)
     }
     useEffect(() => {
-        handleLoad()
+        void handleLoad()
     }, [])
 
     return (

--- a/astro/src/components/Client/bsky/unique/LoadSession.tsx
+++ b/astro/src/components/Client/bsky/unique/LoadSession.tsx
@@ -33,7 +33,7 @@ export const Component = ({
                 const refreshResult = await refreshSession({ refreshJwt: r_jwts })
                 if (typeof refreshResult?.error !== "undefined") {
                     resetJwt()
-                    let e: Error = new Error(refreshResult.message)
+                    const e: Error = new Error(refreshResult.message)
                     e.name = refreshResult.error
                     throw e
                 }
@@ -54,7 +54,7 @@ export const Component = ({
                     setProfile: setProfile
                 })
                 if (typeof resLoadProfile?.error !== "undefined") {
-                    let e: Error = new Error(resLoadProfile.message)
+                    const e: Error = new Error(resLoadProfile.message)
                     e.name = resLoadProfile.error
                     throw e
                 }

--- a/astro/src/components/Client/bsky/unique/LoadSession.tsx
+++ b/astro/src/components/Client/bsky/unique/LoadSession.tsx
@@ -13,6 +13,8 @@ import { readJwt, resetJwt, writeJwt } from "@/utils/useLocalStorage"
 import loadProfile from "../lib/loadProfile";
 import { Session_context, Profile_context } from "../../common/contexts"
 
+import dummyRefreshSessionObject from "@/utils/atproto_api/models/refreshSession.json"
+
 export const Component = ({
     setIsLoad,
     setMsgInfo
@@ -31,26 +33,27 @@ export const Component = ({
                     msg: "セッションの再開中...", isError: false
                 })
                 const refreshResult = await refreshSession({ refreshJwt: r_jwts })
-                if (typeof refreshResult?.error !== "undefined") {
+                if ("error" in refreshResult && typeof refreshResult.error != "undefined") {
                     resetJwt()
                     const e: Error = new Error(refreshResult.message)
                     e.name = refreshResult.error
                     throw e
                 }
+                const refreshSuccessResult = refreshResult as typeof dummyRefreshSessionObject
                 setSession({
-                    did: refreshResult.did,
-                    accessJwt: refreshResult.accessJwt,
-                    refreshJwt: refreshResult.refreshJwt,
-                    handle: refreshResult.handle,
+                    did: refreshSuccessResult.did,
+                    accessJwt: refreshSuccessResult.accessJwt,
+                    refreshJwt: refreshSuccessResult.refreshJwt,
+                    handle: refreshSuccessResult.handle,
                 })
                 // リフレッシュしたトークンを上書き
-                writeJwt(refreshResult.refreshJwt)
+                writeJwt(refreshSuccessResult.refreshJwt)
                 
                 setMsgInfo({
                     msg: "セッションを再開しました!", isError: false
                 })
                 const resLoadProfile = await loadProfile({
-                    session: refreshResult,
+                    session: refreshSuccessResult,
                     setProfile: setProfile
                 })
                 if (typeof resLoadProfile?.error !== "undefined") {

--- a/astro/src/components/Client/bsky/unique/LoadSession.tsx
+++ b/astro/src/components/Client/bsky/unique/LoadSession.tsx
@@ -1,26 +1,23 @@
 // utils
-import {
-    Dispatch, SetStateAction,
-    useContext, useEffect
-} from "react"
+import { Dispatch, SetStateAction, useContext, useEffect } from "react"
 
 // atproto
-import refreshSession from "@/utils/atproto_api/refreshSession";
+import refreshSession from "@/utils/atproto_api/refreshSession"
 
 // service
 import { type msgInfo } from "../../common/types"
 import { readJwt, resetJwt, writeJwt } from "@/utils/useLocalStorage"
-import loadProfile from "../lib/loadProfile";
+import loadProfile from "../lib/loadProfile"
 import { Session_context, Profile_context } from "../../common/contexts"
 
 import dummyRefreshSessionObject from "@/utils/atproto_api/models/refreshSession.json"
 
 export const Component = ({
     setIsLoad,
-    setMsgInfo
+    setMsgInfo,
 }: {
-    setIsLoad: Dispatch<SetStateAction<boolean>>,
-    setMsgInfo: Dispatch<SetStateAction<msgInfo>>,
+    setIsLoad: Dispatch<SetStateAction<boolean>>
+    setMsgInfo: Dispatch<SetStateAction<msgInfo>>
 }) => {
     const { setSession } = useContext(Session_context)
     const { setProfile } = useContext(Profile_context)
@@ -30,16 +27,23 @@ export const Component = ({
             try {
                 // localstorageにsessionが存在していた場合はtokenをrefresh
                 setMsgInfo({
-                    msg: "セッションの再開中...", isError: false
+                    msg: "セッションの再開中...",
+                    isError: false,
                 })
-                const refreshResult = await refreshSession({ refreshJwt: r_jwts })
-                if ("error" in refreshResult && typeof refreshResult.error != "undefined") {
+                const refreshResult = await refreshSession({
+                    refreshJwt: r_jwts,
+                })
+                if (
+                    "error" in refreshResult &&
+                    typeof refreshResult.error != "undefined"
+                ) {
                     resetJwt()
                     const e: Error = new Error(refreshResult.message)
                     e.name = refreshResult.error
                     throw e
                 }
-                const refreshSuccessResult = refreshResult as typeof dummyRefreshSessionObject
+                const refreshSuccessResult =
+                    refreshResult as typeof dummyRefreshSessionObject
                 setSession({
                     did: refreshSuccessResult.did,
                     accessJwt: refreshSuccessResult.accessJwt,
@@ -48,20 +52,20 @@ export const Component = ({
                 })
                 // リフレッシュしたトークンを上書き
                 writeJwt(refreshSuccessResult.refreshJwt)
-                
+
                 setMsgInfo({
-                    msg: "セッションを再開しました!", isError: false
+                    msg: "セッションを再開しました!",
+                    isError: false,
                 })
                 const resLoadProfile = await loadProfile({
                     session: refreshSuccessResult,
-                    setProfile: setProfile
+                    setProfile: setProfile,
                 })
                 if (typeof resLoadProfile?.error !== "undefined") {
                     const e: Error = new Error(resLoadProfile.message)
                     e.name = resLoadProfile.error
                     throw e
                 }
-
             } catch (error: unknown) {
                 let msg: string = "Unexpected Unknown Error"
                 if (error instanceof Error) {
@@ -70,7 +74,7 @@ export const Component = ({
                 if (setMsgInfo !== undefined) {
                     setMsgInfo({
                         msg: msg,
-                        isError: true
+                        isError: true,
                     })
                 }
                 resetJwt()
@@ -82,9 +86,7 @@ export const Component = ({
         void handleLoad()
     }, [])
 
-    return (
-        <></>
-    )
+    return <></>
 }
 
 export default Component

--- a/astro/src/components/Client/bsky/unique/LoadSession.tsx
+++ b/astro/src/components/Client/bsky/unique/LoadSession.tsx
@@ -10,8 +10,6 @@ import { readJwt, resetJwt, writeJwt } from "@/utils/useLocalStorage"
 import loadProfile from "../lib/loadProfile"
 import { Session_context, Profile_context } from "../../common/contexts"
 
-import dummyRefreshSessionObject from "@/utils/atproto_api/models/refreshSession.json"
-
 export const Component = ({
     setIsLoad,
     setMsgInfo,
@@ -34,31 +32,28 @@ export const Component = ({
                     refreshJwt: r_jwts,
                 })
                 if (
-                    "error" in refreshResult &&
-                    typeof refreshResult.error != "undefined"
+                    "error" in refreshResult
                 ) {
                     resetJwt()
                     const e: Error = new Error(refreshResult.message)
                     e.name = refreshResult.error
                     throw e
                 }
-                const refreshSuccessResult =
-                    refreshResult as typeof dummyRefreshSessionObject
                 setSession({
-                    did: refreshSuccessResult.did,
-                    accessJwt: refreshSuccessResult.accessJwt,
-                    refreshJwt: refreshSuccessResult.refreshJwt,
-                    handle: refreshSuccessResult.handle,
+                    did: refreshResult.did,
+                    accessJwt: refreshResult.accessJwt,
+                    refreshJwt: refreshResult.refreshJwt,
+                    handle: refreshResult.handle,
                 })
                 // リフレッシュしたトークンを上書き
-                writeJwt(refreshSuccessResult.refreshJwt)
+                writeJwt(refreshResult.refreshJwt)
 
                 setMsgInfo({
                     msg: "セッションを再開しました!",
                     isError: false,
                 })
                 const resLoadProfile = await loadProfile({
-                    session: refreshSuccessResult,
+                    session: refreshResult,
                     setProfile: setProfile,
                 })
                 if (typeof resLoadProfile?.error !== "undefined") {

--- a/astro/src/components/Client/bsky/unique/TagInputList.tsx
+++ b/astro/src/components/Client/bsky/unique/TagInputList.tsx
@@ -21,7 +21,7 @@ export const Component = ({
             outputText = [tag + " "].join("")
         } else {
             // 末尾が改行文字か、半角文字の場合は区切り記号を挿入しない
-            console.log(`last : \"${postText.slice(-1)}\"`)
+            console.log(`last : "${postText.slice(-1)}"`)
             outputText = [postText,
                 new RegExp(/[ \n\r]/).test(
                     postText.slice(-1)) ? "" : " ",

--- a/astro/src/components/Client/bsky/unique/TagInputList.tsx
+++ b/astro/src/components/Client/bsky/unique/TagInputList.tsx
@@ -1,17 +1,17 @@
 // utils
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react"
 
 // service
-import { button_base } from "../../common/tailwindVariants";
-import { readSavedTags } from "@/utils/useLocalStorage";
+import { button_base } from "../../common/tailwindVariants"
+import { readSavedTags } from "@/utils/useLocalStorage"
 
 export const Component = ({
     disabled,
     postText,
-    setPostText
+    setPostText,
 }: {
-    disabled: boolean,
-    postText: string,
+    disabled: boolean
+    postText: string
     setPostText: Dispatch<SetStateAction<string>>
 }) => {
     const handleClick = (tag: string) => {
@@ -22,17 +22,20 @@ export const Component = ({
         } else {
             // 末尾が改行文字か、半角文字の場合は区切り記号を挿入しない
             console.log(`last : "${postText.slice(-1)}"`)
-            outputText = [postText,
-                new RegExp(/[ \n\r]/).test(
-                    postText.slice(-1)) ? "" : " ",
-                tag].join("")
+            outputText = [
+                postText,
+                new RegExp(/[ \n\r]/).test(postText.slice(-1)) ? "" : " ",
+                tag,
+            ].join("")
         }
         setPostText(outputText)
     }
     const TagButton = ({ tag }: { tag: string }) => {
         return (
             <button
-                onClick={() => { handleClick(tag) }}
+                onClick={() => {
+                    handleClick(tag)
+                }}
                 className={button_base({
                     disabled: disabled,
                     class: [
@@ -43,23 +46,21 @@ export const Component = ({
                         "px-3",
                         "w-fit",
                         "inline-block",
-                        "whitespace-nowrap"
+                        "whitespace-nowrap",
                     ],
-                    noshadow: true
-                })}>
+                    noshadow: true,
+                })}
+            >
                 {tag}
             </button>
         )
     }
     return (
         <div className="my-auto overflow-x-scroll flex w-fit minimum-scrollbars">
-            {
-                readSavedTags().map((value, index) => {
-                    return <TagButton key={`${index}-${value}`} tag={value} />
-                })
-            }
+            {readSavedTags().map((value, index) => {
+                return <TagButton key={`${index}-${value}`} tag={value} />
+            })}
         </div>
     )
-
 }
 export default Component

--- a/astro/src/components/Client/bsky/unique/TagInputList.tsx
+++ b/astro/src/components/Client/bsky/unique/TagInputList.tsx
@@ -54,8 +54,8 @@ export const Component = ({
     return (
         <div className="my-auto overflow-x-scroll flex w-fit minimum-scrollbars">
             {
-                readSavedTags().map((value) => {
-                    return <TagButton tag={value} />
+                readSavedTags().map((value, index) => {
+                    return <TagButton key={`${index}-${value}`} tag={value} />
                 })
             }
         </div>

--- a/astro/src/components/Client/bsky/unique/TextInputBox.tsx
+++ b/astro/src/components/Client/bsky/unique/TextInputBox.tsx
@@ -147,7 +147,7 @@ const Component = ({
             })
             const segments = segmenterJa.segment(postText)
             return Array.from(segments).length
-        } catch (e) {
+        } catch (_e) {
             // Intl.Segmenterがfirefoxでは未対応であるため、やむをえずレガシーな方法で対処
             // 絵文字のカウント数が想定より多く設定されてしまうため、firefox_v125までは非推奨ブラウザとする
             return postText.length

--- a/astro/src/components/Client/bsky/unique/TextInputBox.tsx
+++ b/astro/src/components/Client/bsky/unique/TextInputBox.tsx
@@ -147,7 +147,7 @@ const Component = ({
             })
             const segments = segmenterJa.segment(postText)
             return Array.from(segments).length
-        } catch (_e) {
+        } catch (_) {
             // Intl.Segmenterがfirefoxでは未対応であるため、やむをえずレガシーな方法で対処
             // 絵文字のカウント数が想定より多く設定されてしまうため、firefox_v125までは非推奨ブラウザとする
             return postText.length

--- a/astro/src/utils/atproto_api/uploadBlob.ts
+++ b/astro/src/utils/atproto_api/uploadBlob.ts
@@ -2,7 +2,7 @@ import getEndpoint, { com_atproto } from "./base"
 const apiName = com_atproto.repo.uploadBlob
 const endpoint = getEndpoint(apiName)
 
-type uploadBlobSuccessResult = {
+export type uploadBlobSuccessResult = {
     blob: {
         $type: "blob"
         ref: {
@@ -13,7 +13,7 @@ type uploadBlobSuccessResult = {
     }
 }
 
-type uploadBlobErrorResult = {
+export type uploadBlobErrorResult = {
     error: string
     message: string
 }


### PR DESCRIPTION
Resolves #55 

以下のPRによる変更を前提に修正しています。
- #81

本PRのマージする場合、上記PRのレビューもお願いします。

## 本PRで行われた変更

- 再代入のない変数をconst宣言に変更 (d8fd91a35d1d3081dac534d1e70200e9e3297f8b)
- `target="_blank"`付のタグの脆弱性対策を追加 (40f97ec5cc7fe909e5d203356fe16ca490f16d1a)
  - ESLintの警告のため対応していますが、ほとんどの新しいブラウザではこの脆弱性がありません。詳細は下記を参考にしてください
    - [\<a>: アンカー要素 - セキュリティとプライバシー | MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Element/a#%E3%82%BB%E3%82%AD%E3%83%A5%E3%83%AA%E3%83%86%E3%82%A3%E3%81%A8%E3%83%97%E3%83%A9%E3%82%A4%E3%83%90%E3%82%B7%E3%83%BC)
    - [Referer ヘッダーのプライバシーとセキュリティの考慮事項 | MDN](https://developer.mozilla.org/ja/docs/Web/Security/Referer_header:_privacy_and_security_concerns)
- `readDrafts()`の戻り値が`string[]`でfalsy値になることが無いようなので、空の配列を代入する処理を削除 (624cf9e6690ccf2f834365fa39f26e97811dbb04)
- 戻り値が`Promise<void>`の関数使用箇所にvoidキーワードを追加 (c8c9587c6bcd7d8e1bffb8bc802351d05c1a9201)
- 利用されていないエスケープを削除 (7afa8cb207adef4551646a43135b5bee99891f1e)
- `identifier`の綴りを修正 (fc6aca651b8e6ed29370aa60e0c2be5b6f37a72c)
- `map()`で繰り返されるコンポーネントに`key`属性を追加 (d5221f372d20509d5ea4fd9ea0f03f63f26f7b12)
- 使用されていないエラー変数の名前にアンダースコアを追加 (5dde2ec13f8d6a8106d78e6e5771d25f0569395f)
- `atproto_api`の型仕様変更に伴い、既存の実装の型情報を更新 (82ad2cd80392c261a9db4c323bc167d9f312378b, ac8f1d7991e0ca4e18f0087a8e2c89008bf9cfe1)
- `Prettier`を適用 (7c1baacc03e8f0bf7a32e76f89d6dd0fbc0d29c9)