### PR TITLE
[Improve code]: components/Client/common/* 手動formatter・Linter対応

### DIFF
--- a/astro/src/components/Client/common/Details.tsx
+++ b/astro/src/components/Client/common/Details.tsx
@@ -1,5 +1,5 @@
-import { useState, ReactNode, useEffect } from 'react'
-import { link } from "./tailwindVariants";
+import { useState, ReactNode, useEffect } from "react"
+import { link } from "./tailwindVariants"
 
 const Component = ({
     summaryLabel,
@@ -19,9 +19,16 @@ const Component = ({
     }, [initHidden])
     return (
         <>
-            <button className={link({ class: "block text-sm" })}
-                onClick={onClick}>{summaryLabel}{hidden ? ("▼") : ("△")}</button>
-            <div className={`transition-all pt-1 ${hidden ? ("hidden h-0") : ("h-full")}`}>
+            <button
+                className={link({ class: "block text-sm" })}
+                onClick={onClick}
+            >
+                {summaryLabel}
+                {hidden ? "▼" : "△"}
+            </button>
+            <div
+                className={`transition-all pt-1 ${hidden ? "hidden h-0" : "h-full"}`}
+            >
                 {children}
             </div>
         </>

--- a/astro/src/components/Client/common/LoadingCircle.tsx
+++ b/astro/src/components/Client/common/LoadingCircle.tsx
@@ -1,10 +1,5 @@
-
-import { load_circle } from "./tailwindVariants";
-const Component = ({
-    size
-}: {
-    size: "s" | "l"
-}) => {
+import { load_circle } from "./tailwindVariants"
+const Component = ({ size }: { size: "s" | "l" }) => {
     return (
         <svg
             className={load_circle({ size: size })}
@@ -17,7 +12,8 @@ const Component = ({
                 stroke="#7dd3fc"
                 fill="none"
                 strokeWidth={20}
-                strokeLinecap="round"></path>
+                strokeLinecap="round"
+            ></path>
         </svg>
     )
 }

--- a/astro/src/components/Client/common/ModeSelectButton.tsx
+++ b/astro/src/components/Client/common/ModeSelectButton.tsx
@@ -2,12 +2,15 @@ import { Dispatch, SetStateAction, useState, useEffect } from "react"
 import { type modes } from "./types"
 import ProcButton from "./ProcButton"
 
-const Component = ({ mode, setMode, isProcessing }: {
+const Component = ({
+    mode,
+    setMode,
+    isProcessing,
+}: {
     isProcessing: boolean
     mode: modes
     setMode: Dispatch<SetStateAction<modes>>
-}
-) => {
+}) => {
     const [label, setLabel] = useState<string>("")
     const swichLabel = () => {
         switch (mode) {
@@ -46,7 +49,8 @@ const Component = ({ mode, setMode, isProcessing }: {
             isProcessing={false}
             context={label}
             showAnimation={false}
-            disabled={isProcessing} />
+            disabled={isProcessing}
+        />
     )
 }
 export default Component

--- a/astro/src/components/Client/common/OverlayDialog.tsx
+++ b/astro/src/components/Client/common/OverlayDialog.tsx
@@ -1,5 +1,5 @@
 // utils
-import { KeyboardEvent, useRef, ReactNode } from "react";
+import { KeyboardEvent, useRef, ReactNode } from "react"
 
 /**
  * Dialogの共通コンポーネント
@@ -13,31 +13,31 @@ export const Component = ({
     callbackOpenDialog,
     callbackCloseDialog,
     buttonOption,
-    children
+    children,
 }: {
-    callbackOpenDialog?: () => void,
-    callbackCloseDialog?: () => void,
+    callbackOpenDialog?: () => void
+    callbackCloseDialog?: () => void
     buttonOption: {
-        className: string,
+        className: string
         content: ReactNode
     }
     children: ReactNode
 }) => {
-    const ref = useRef<HTMLDialogElement | null>(null);
+    const ref = useRef<HTMLDialogElement | null>(null)
 
     const handleOpenDialog = () => {
         typeof callbackOpenDialog !== "undefined" && callbackOpenDialog()
         if (ref.current) {
             ref.current.showModal()
         }
-    };
+    }
 
     const handleCloseDialog = () => {
         if (ref.current) {
-            ref.current.close();
+            ref.current.close()
         }
         typeof callbackCloseDialog !== "undefined" && callbackCloseDialog()
-    };
+    }
 
     const handleKeyDown = (event: KeyboardEvent<HTMLDialogElement>) => {
         if (event.key === "Escape") {
@@ -49,16 +49,19 @@ export const Component = ({
         <>
             <button
                 onClick={handleOpenDialog}
-                className={buttonOption.className}>
+                className={buttonOption.className}
+            >
                 {buttonOption.content}
             </button>
-            <dialog ref={ref}
+            <dialog
+                ref={ref}
                 className="p-10 rounded-2xl"
                 onClick={handleCloseDialog}
-                onKeyDown={handleKeyDown}>
+                onKeyDown={handleKeyDown}
+            >
                 {children}
             </dialog>
         </>
-    );
-};
+    )
+}
 export default Component

--- a/astro/src/components/Client/common/ProcButton.tsx
+++ b/astro/src/components/Client/common/ProcButton.tsx
@@ -15,47 +15,57 @@ const Component = ({
     color,
     hidden,
 }: {
-    handler: () => void,
+    handler: () => void
     buttonID?: buttonID
-    isProcessing: boolean,
-    context: ReactNode,
-    showAnimation?: boolean,
-    className?: Array<string>,
-    disabled?: boolean,
-    hidden?: boolean,
-    color?: "blue",
+    isProcessing: boolean
+    context: ReactNode
+    showAnimation?: boolean
+    className?: Array<string>
+    disabled?: boolean
+    hidden?: boolean
+    color?: "blue"
 }) => {
-    const { clickedButtonID, setClickedButtonID } = useContext(clickedButtonContext)
+    const { clickedButtonID, setClickedButtonID } =
+        useContext(clickedButtonContext)
     const handlerWrapper = (callback: () => void) => {
         callback()
-        const thisButtonID = (typeof buttonID !== "undefined") ? buttonID : ""
+        const thisButtonID = typeof buttonID !== "undefined" ? buttonID : ""
         setClickedButtonID(thisButtonID)
     }
-    const Animation = clickedButtonID !== "" && clickedButtonID === buttonID && showAnimation
+    const Animation =
+        clickedButtonID !== "" && clickedButtonID === buttonID && showAnimation
     return (
-        <button onClick={() => handlerWrapper(handler)}
+        <button
+            onClick={() => handlerWrapper(handler)}
             className={button_base({
-                disabled: (isProcessing || disabled),
+                disabled: isProcessing || disabled,
                 regectinput: disabled,
                 class: className,
                 color: color,
                 hidden: hidden,
-                noshadow: disabled
+                noshadow: disabled,
             })}
-            type="button" disabled={(isProcessing || disabled)}>
-            {
-                isProcessing ? (
-                    Animation ? (
-                        <span className={["flex", "items-center", "w-fit", "mx-auto"].join(" ")}>
-                            <Loadingcircle size="s" />
-                        </span>
-                    ) : (
-                        <>{context}</>
-                    )
+            type="button"
+            disabled={isProcessing || disabled}
+        >
+            {isProcessing ? (
+                Animation ? (
+                    <span
+                        className={[
+                            "flex",
+                            "items-center",
+                            "w-fit",
+                            "mx-auto",
+                        ].join(" ")}
+                    >
+                        <Loadingcircle size="s" />
+                    </span>
                 ) : (
                     <>{context}</>
                 )
-            }
+            ) : (
+                <>{context}</>
+            )}
         </button>
     )
 }

--- a/astro/src/components/Client/common/SelectList.tsx
+++ b/astro/src/components/Client/common/SelectList.tsx
@@ -1,31 +1,34 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react"
 
 type codeMap = {
-    label: string,
-    code: any,
+    label: string
+    code: any
 }
 export const Component = ({
     disabled,
     setCode,
-    codeMap
+    codeMap,
 }: {
-    disabled: boolean,
-    setCode: Dispatch<SetStateAction<any>>,
+    disabled: boolean
+    setCode: Dispatch<SetStateAction<any>>
     codeMap: Array<codeMap>
 }) => {
     const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
         let value: any = null
-        const item = codeMap.find((opt) => opt.label === event.target.value)
+        const item = codeMap.find(opt => opt.label === event.target.value)
         if (typeof item !== "undefined") {
             value = item.code
         }
         setCode(value)
     }
     return (
-        <>
-            <div className={[
-                "p-0", "h-8", "text-sm",
-                "my-auto", "rounded-lg",
+        <div
+            className={[
+                "p-0",
+                "h-8",
+                "text-sm",
+                "my-auto",
+                "rounded-lg",
                 "relative",
                 "border-2",
                 "after:my-auto",
@@ -36,29 +39,30 @@ export const Component = ({
                 "after:bottom-0",
                 "after:h-fit",
                 "after:text-gray-300",
-                "after:pointer-events-none"
-            ].join(" ")}>
-                <select
-                    onChange={handleSelect}
-                    disabled={disabled}
-                    className={[
-                        "appearance-none",
-                        "block", "h-full", "w-full",
-                        "pl-2", "pr-6", "py-1",
-                        "bg-white",
-                        "rounded-lg",
-                        "disabled:bg-gray-200"
-                    ].join(" ")}>
-                    {codeMap.map((value) => {
-                        return (
-                            <option key={value.label}>
-                                {value.label}
-                            </option>
-                        )
-                    })}
-                </select>
-            </div>
-        </>
+                "after:pointer-events-none",
+            ].join(" ")}
+        >
+            <select
+                onChange={handleSelect}
+                disabled={disabled}
+                className={[
+                    "appearance-none",
+                    "block",
+                    "h-full",
+                    "w-full",
+                    "pl-2",
+                    "pr-6",
+                    "py-1",
+                    "bg-white",
+                    "rounded-lg",
+                    "disabled:bg-gray-200",
+                ].join(" ")}
+            >
+                {codeMap.map(value => {
+                    return <option key={value.label}>{value.label}</option>
+                })}
+            </select>
+        </div>
     )
 }
 export default Component

--- a/astro/src/components/Client/common/SelectList.tsx
+++ b/astro/src/components/Client/common/SelectList.tsx
@@ -1,25 +1,27 @@
 import { Dispatch, SetStateAction } from "react"
 
-type codeMap = {
+type CodeMap<CodeType> = {
     label: string
-    code: any
+    code: CodeType
 }
-export const Component = ({
+export const Component = <CodeType,>({
     disabled,
     setCode,
     codeMap,
 }: {
     disabled: boolean
-    setCode: Dispatch<SetStateAction<any>>
-    codeMap: Array<codeMap>
+    setCode: Dispatch<SetStateAction<CodeType>>
+    codeMap: CodeMap<CodeType>[]
 }) => {
     const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        let value: any = null
-        const item = codeMap.find(opt => opt.label === event.target.value)
-        if (typeof item !== "undefined") {
-            value = item.code
+        const item: CodeMap<CodeType> | undefined = codeMap.find(
+            opt => opt.label === event.target.value,
+        )
+        const code: CodeType | undefined = item?.code ?? codeMap[0]?.code
+
+        if (typeof code !== "undefined") {
+            setCode(code)
         }
-        setCode(value)
     }
     return (
         <div

--- a/astro/src/components/Client/common/SelectList.tsx
+++ b/astro/src/components/Client/common/SelectList.tsx
@@ -14,6 +14,10 @@ export const Component = <CodeType,>({
     codeMap: CodeMap<CodeType>[]
 }) => {
     const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        if (codeMap.length === 0) {
+            return
+        }
+
         const item: CodeMap<CodeType> | undefined = codeMap.find(
             opt => opt.label === event.target.value,
         )

--- a/astro/src/components/Client/common/SelectList.tsx
+++ b/astro/src/components/Client/common/SelectList.tsx
@@ -21,11 +21,11 @@ export const Component = <CodeType,>({
         const item: CodeMap<CodeType> | undefined = codeMap.find(
             opt => opt.label === event.target.value,
         )
-        const code: CodeType | undefined = item?.code ?? codeMap[0]?.code
 
-        if (typeof code !== "undefined") {
-            setCode(code)
-        }
+        // itemが取得できなかった場合、codeMapの最初の項を採用する。
+        const code: CodeType = item === undefined ? codeMap[0].code : item.code
+
+        setCode(code)
     }
     return (
         <div

--- a/astro/src/components/Client/common/ToggleSwitch.tsx
+++ b/astro/src/components/Client/common/ToggleSwitch.tsx
@@ -8,13 +8,15 @@ const Component = ({
     setPropConfig,
 }: {
     labeltext: ReactNode
-    prop: boolean,
+    prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
     initialValue: boolean
     setPropConfig: (flag: boolean) => void
 }) => {
-    const inputRef = useRef<HTMLInputElement>(null!);
-    const handleClick = () => { inputRef.current.click() }
+    const inputRef = useRef<HTMLInputElement>(null!)
+    const handleClick = () => {
+        inputRef.current.click()
+    }
 
     const setPropAll = (checked: boolean) => {
         setProp(checked)
@@ -39,16 +41,17 @@ const Component = ({
                     checked={prop}
                     onChange={handleCheck}
                     type="checkbox"
-                    className="peer sr-only" />
+                    className="peer sr-only"
+                />
                 <label className="text-sm">{labeltext}:&nbsp;</label>
-                <span onClick={handleClick}
+                <span
+                    onClick={handleClick}
                     className="my-auto block w-8 bg-gray-500 rounded-full p-[1px] 
                         after:block after:h-4 after:w-4 after:rounded-full 
                         after:bg-white after:transition 
                         peer-checked:bg-blue-500 
                         peer-checked:after:translate-x-[calc(100%-2px)]"
-                >
-                </span>
+                ></span>
             </div>
         </>
     )

--- a/astro/src/components/Client/common/Tooltip.tsx
+++ b/astro/src/components/Client/common/Tooltip.tsx
@@ -1,25 +1,25 @@
-import { memo, useRef, useEffect, ReactNode } from "react";
+import { memo, useRef, useEffect, ReactNode } from "react"
 
 export const Component = ({
     tooltip,
     children,
 }: {
-    tooltip: ReactNode;
+    tooltip: ReactNode
     children: ReactNode
 }) => {
-    const ref = useRef<HTMLDivElement>(null);
+    const ref = useRef<HTMLDivElement>(null)
 
     const handleMouseEnter = () => {
-        if (!ref.current) return;
-        ref.current.style.opacity = "1";
-        ref.current.style.visibility = "visible";
-    };
+        if (!ref.current) return
+        ref.current.style.opacity = "1"
+        ref.current.style.visibility = "visible"
+    }
 
     const handleMouseLeave = () => {
-        if (!ref.current) return;
-        ref.current.style.opacity = "0";
-        ref.current.style.visibility = "hidden";
-    };
+        if (!ref.current) return
+        ref.current.style.opacity = "0"
+        ref.current.style.visibility = "hidden"
+    }
     useEffect(() => {
         handleMouseLeave()
     }, [])
@@ -33,12 +33,16 @@ export const Component = ({
             >
                 {tooltip}
             </div>
-            <div className="w-fit h-fit m-auto" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+            <div
+                className="w-fit h-fit m-auto"
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            >
                 {children}
             </div>
         </div>
-    );
-};
+    )
+}
 
 const memoTooltip = memo(Component)
 export default memoTooltip

--- a/astro/src/components/Client/common/Tweetbox.tsx
+++ b/astro/src/components/Client/common/Tweetbox.tsx
@@ -1,11 +1,8 @@
-import { ReactNode } from "react";
-export const Component = ({
-    children,
-}: {
-    children: ReactNode
-}) => {
+import { ReactNode } from "react"
+export const Component = ({ children }: { children: ReactNode }) => {
     return (
-        <div className="mx-auto
+        <div
+            className="mx-auto
                         sm:max-w-xl 
                         bg-white 
                         rounded-lg
@@ -13,10 +10,11 @@ export const Component = ({
                         sm:border-y-[10px]
                         border-white 
                         shadow-md
-                        py-2 border-y-8">
+                        py-2 border-y-8"
+        >
             {children}
         </div>
     )
-};
+}
 
 export default Component

--- a/astro/src/components/Client/common/contexts.ts
+++ b/astro/src/components/Client/common/contexts.ts
@@ -1,26 +1,32 @@
-import React, {
-    createContext
-} from "react"
-import type getProfile from "@/utils/atproto_api/models/getProfile.json";
-import { buttonID } from "../bsky/types";
+import React, { createContext } from "react"
+import type getProfile from "@/utils/atproto_api/models/getProfile.json"
+import { buttonID } from "../bsky/types"
 
 export type Session_info = {
-    did: string,
-    accessJwt: string,
-    refreshJwt: string | null,
-    handle: string | null,
+    did: string
+    accessJwt: string
+    refreshJwt: string | null
+    handle: string | null
 }
-export const Session_context = createContext({} as {
-    session: Session_info
-    setSession: React.Dispatch<React.SetStateAction<Session_info>>
-})
+export const Session_context = createContext(
+    {} as {
+        session: Session_info
+        setSession: React.Dispatch<React.SetStateAction<Session_info>>
+    },
+)
 
-export const Profile_context = createContext({} as {
-    profile: typeof getProfile | null
-    setProfile: React.Dispatch<React.SetStateAction<typeof getProfile | null>>
-})
+export const Profile_context = createContext(
+    {} as {
+        profile: typeof getProfile | null
+        setProfile: React.Dispatch<
+            React.SetStateAction<typeof getProfile | null>
+        >
+    },
+)
 
-export const clickedButtonContext = createContext({} as {
-    clickedButtonID: buttonID
-    setClickedButtonID: React.Dispatch<React.SetStateAction<buttonID>>
-})
+export const clickedButtonContext = createContext(
+    {} as {
+        clickedButtonID: buttonID
+        setClickedButtonID: React.Dispatch<React.SetStateAction<buttonID>>
+    },
+)

--- a/astro/src/components/Client/common/types.ts
+++ b/astro/src/components/Client/common/types.ts
@@ -2,26 +2,26 @@ import { ogpMetaData } from "@/lib/api/types"
 export type modes = "bsky" | "pagedb" | "xcom"
 
 export type msgInfo = {
-    msg: string,
-    isError: boolean,
+    msg: string
+    isError: boolean
 }
 
 export type MediaData = LinkCard | Images | null
 type LinkCard = {
-    type: "external",
+    type: "external"
     // 処理の便宜上 Imagesと同様にArrayとしているが
     // 実際は項目数1の配列。改善したい。
     images: Array<{
-        blob: Blob | null,
+        blob: Blob | null
     }>
     meta: ogpMetaData & {
         url: string
     }
 }
 type Images = {
-    type: "images",
+    type: "images"
     images: Array<{
-        alt: string,
-        blob: Blob,
+        alt: string
+        blob: Blob
     }>
 }


### PR DESCRIPTION
Resolves #59
以下の対応を行いました。
- 1064677611a23278316bca52db193ad16862451b `src/components/Client/common/*`にPrettierを適用 
- 5982e581df5ed7e6a5d2174ecaf064aeefd9b682 セレクトボックス共通実装にて、`codeMap`にジェネリック型を導入