### PR TITLE
[Improve code]: 繰り返し表示される要素のkeyから、配列のインデックス番号を取り除く

### DIFF
--- a/astro/src/components/Client/bsky/unique/DraftDialog.tsx
+++ b/astro/src/components/Client/bsky/unique/DraftDialog.tsx
@@ -78,7 +78,7 @@ export const Component = ({
                 {drafts.length > 0 ? (
                     drafts.map((draft, index) => (
                         <div
-                            key={index}
+                            key={`draft-${draft}`}
                             className={
                                 ["flex", "mb-0", "items-center", "py-4"].join(
                                     " ",

--- a/astro/src/components/Client/bsky/unique/TagInputList.tsx
+++ b/astro/src/components/Client/bsky/unique/TagInputList.tsx
@@ -57,8 +57,8 @@ export const Component = ({
     }
     return (
         <div className="my-auto overflow-x-scroll flex w-fit minimum-scrollbars">
-            {readSavedTags().map((value, index) => {
-                return <TagButton key={`${index}-${value}`} tag={value} />
+            {readSavedTags().map(value => {
+                return <TagButton key={`tag-${value}`} tag={value} />
             })}
         </div>
     )

--- a/astro/src/components/Client/common/SelectList.tsx
+++ b/astro/src/components/Client/common/SelectList.tsx
@@ -65,7 +65,11 @@ export const Component = <CodeType,>({
                 ].join(" ")}
             >
                 {codeMap.map(value => {
-                    return <option key={value.label}>{value.label}</option>
+                    return (
+                        <option key={`select-list-code-${value.label}`}>
+                            {value.label}
+                        </option>
+                    )
                 })}
             </select>
         </div>

--- a/astro/src/components/Client/intents/PopupPreviewForm.tsx
+++ b/astro/src/components/Client/intents/PopupPreviewForm.tsx
@@ -27,9 +27,9 @@ export const Component = ({
                     <div className="text-left ml-3 break-all">
                         {popupPreviewOptions.postText
                             .split(/(\n)/)
-                            .map((value, index) => {
+                            .map(value => {
                                 return (
-                                    <Fragment key={index}>
+                                    <Fragment key={`preview-text-${value}`}>
                                         {value.match(/\n/) ? <br /> : value}
                                     </Fragment>
                                 )

--- a/astro/src/components/Client/pagedb/PageViewForm.tsx
+++ b/astro/src/components/Client/pagedb/PageViewForm.tsx
@@ -66,7 +66,7 @@ const Component = ({
                         {ids.ids.map(value => {
                             return (
                                 <div
-                                    key={value}
+                                    key={`page-id-${value}`}
                                     className=" bg-white rounded-lg px-2 py-1 m-1 border-2"
                                 >
                                     <a


### PR DESCRIPTION
Resolves #100

繰り返し表示されるReactノードの`key`に`[要素の簡易な説明]-${一意の値}`を再定義しました
レビューをお願いします