### PR TITLE
[Feature Request]: 外部サービスからSkyshareへ入力を送りたい

### DIFF
--- a/astro/public/materials/manifest.webmanifest
+++ b/astro/public/materials/manifest.webmanifest
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json.schemastore.org/web-manifest-combined.json",
     "name": "Skyshare",
     "short_name": "Skyshare",
     "start_url": "/",
@@ -11,11 +12,21 @@
             "sizes": "any",
             "type": "image/svg+xml",
             "purpose": "any"
-        },{
+        },
+        {
             "src": "/materials/icon-512.png",
             "sizes": "512x512",
             "type": "image/png"
         }
-    ]
+    ],
+    "share_target": {
+        "action": "/app",
+        "method": "GET",
+        "enctype": "application/x-www-form-urlencoded",
+        "params": {
+            "title": "sharedTitle",
+            "text": "sharedText",
+            "url": "sharedUrl"
+        }
+    }
 }
-  

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -37,20 +37,25 @@ export type callbackPostOptions = {
     previewData: Blob | null
 }
 
+/**
+ * リクエストパラメータから投稿テキストの初期値を生成します
+ * @param searchParams リクエストパラメータ
+ * @returns 投稿テキストの初期値
+ */
 const createInitialPostText = (searchParams: URLSearchParams) => {
     const shared_title: string | null = searchParams.get("sharedTitle")
-    const shared_url: string | null = searchParams.get("sharedUrl")
     const shared_text: string | null = searchParams.get("sharedText")
+    const shared_url: string | null = searchParams.get("sharedUrl")
 
     let shared_content: string = ""
     if (shared_title !== null) {
         shared_content += `${shared_title}\n`
     }
-    if (shared_url !== null) {
-        shared_content += `${shared_url}\n`
-    }
     if (shared_text !== null) {
         shared_content += `${shared_text}\n`
+    }
+    if (shared_url !== null) {
+        shared_content += `${shared_url}\n`
     }
     return shared_content
 }

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -14,7 +14,9 @@ import LanguageSelectList from "./selectLists/LanguageSelectList"
 import Details from "../common/Details"
 import TagInputList from "./unique/TagInputList"
 import SelfLabelsSelectList from "./selectLists/SelfLabelsSelectList"
-import LinkcardAttachButton from "./buttons/LinkcardAttachButton"
+import LinkcardAttachButton, {
+    handleGetOGP,
+} from "./buttons/LinkcardAttachButton"
 import PostButton from "./buttons/PostButton"
 import AddImageButton from "./buttons/AddImageButton"
 import MediaPreview from "./MediaPreview"
@@ -82,6 +84,8 @@ const Component = ({
     setMediaData: Dispatch<SetStateAction<MediaData>>
     setPopupPreviewOptions: Dispatch<SetStateAction<popupPreviewOptions>>
 }) => {
+    // 配置されたページのURL
+    const siteurl = location.origin
     // Post内容を格納する変数とディスパッチャー
     const [postText, setPostText] = useState<string>(initialPostText)
     // Postの実行状態を管理する変数とディスパッチャー
@@ -109,6 +113,19 @@ const Component = ({
             e.preventDefault()
         }
         window.addEventListener("dragover", handleDragOver)
+        const getOGP = async () => {
+            await handleGetOGP({
+                postText,
+                setProcessing,
+                setMsgInfo,
+                siteurl,
+                setMediaData,
+            })
+        }
+        if (postText !== "") {
+            getOGP().catch((_: unknown) => {})
+        }
+
         return () => {
             window.removeEventListener("dragover", handleDragOver)
         }
@@ -213,6 +230,7 @@ const Component = ({
                 />
             </TextInputBox>
             <LinkcardAttachButton
+                siteurl={siteurl}
                 postText={postText}
                 setMediaData={setMediaData}
                 isProcessing={isProcessing}

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -43,21 +43,21 @@ export type callbackPostOptions = {
  * @returns 投稿テキストの初期値
  */
 const createInitialPostText = (searchParams: URLSearchParams) => {
-    const shared_title: string | null = searchParams.get("sharedTitle")
-    const shared_text: string | null = searchParams.get("sharedText")
-    const shared_url: string | null = searchParams.get("sharedUrl")
+    const sharedTitle: string | null = searchParams.get("sharedTitle")
+    const sharedText: string | null = searchParams.get("sharedText")
+    const sharedUrl: string | null = searchParams.get("sharedUrl")
 
-    let shared_content: string = ""
-    if (shared_title !== null) {
-        shared_content += `${shared_title}\n`
+    let sharedContent: string = ""
+    if (sharedTitle !== null) {
+        sharedContent += `${sharedTitle}\n`
     }
-    if (shared_text !== null) {
-        shared_content += `${shared_text}\n`
+    if (sharedText !== null) {
+        sharedContent += `${sharedText}\n`
     }
-    if (shared_url !== null) {
-        shared_content += `${shared_url}\n`
+    if (sharedUrl !== null) {
+        sharedContent += `${sharedUrl}\n`
     }
-    return shared_content
+    return sharedContent
 }
 
 /** リクエストパラメータ */

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -55,6 +55,11 @@ const createInitialPostText = (searchParams: URLSearchParams) => {
     return shared_content
 }
 
+/** リクエストパラメータ */
+const searchParams = new URLSearchParams(window.location.search)
+/** 投稿テキストの初期値 */
+const initialPostText: string = createInitialPostText(searchParams)
+
 const Component = ({
     setMsgInfo,
     isProcessing,
@@ -72,9 +77,6 @@ const Component = ({
     setMediaData: Dispatch<SetStateAction<MediaData>>
     setPopupPreviewOptions: Dispatch<SetStateAction<popupPreviewOptions>>
 }) => {
-    const searchParams = new URLSearchParams(window.location.search)
-    const initialPostText = createInitialPostText(searchParams)
-
     // Post内容を格納する変数とディスパッチャー
     const [postText, setPostText] = useState<string>(initialPostText)
     // Postの実行状態を管理する変数とディスパッチャー

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -37,6 +37,24 @@ export type callbackPostOptions = {
     previewData: Blob | null
 }
 
+const createInitialPostText = (searchParams: URLSearchParams) => {
+    const shared_title: string | null = searchParams.get("sharedTitle")
+    const shared_url: string | null = searchParams.get("sharedUrl")
+    const shared_text: string | null = searchParams.get("sharedText")
+
+    let shared_content: string = ""
+    if (shared_title !== null) {
+        shared_content += `${shared_title}\n`
+    }
+    if (shared_url !== null) {
+        shared_content += `${shared_url}\n`
+    }
+    if (shared_text !== null) {
+        shared_content += `${shared_text}\n`
+    }
+    return shared_content
+}
+
 const Component = ({
     setMsgInfo,
     isProcessing,
@@ -54,8 +72,11 @@ const Component = ({
     setMediaData: Dispatch<SetStateAction<MediaData>>
     setPopupPreviewOptions: Dispatch<SetStateAction<popupPreviewOptions>>
 }) => {
+    const searchParams = new URLSearchParams(window.location.search)
+    const initialPostText = createInitialPostText(searchParams)
+
     // Post内容を格納する変数とディスパッチャー
-    const [postText, setPostText] = useState<string>("")
+    const [postText, setPostText] = useState<string>(initialPostText)
     // Postの実行状態を管理する変数とディスパッチャー
     const [language, setLanguage] = useState<string>("ja")
     // 下書きのstate情報

--- a/astro/src/components/Client/bsky/buttons/LinkcardAttachButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/LinkcardAttachButton.tsx
@@ -11,95 +11,126 @@ import { getOgpMeta, getOgpBlob } from "@/lib/getOgp"
 import { richTextFacetParser } from "@/utils/richTextParser"
 import { msgInfo, MediaData } from "../../common/types"
 
+const handleGetOGP = async ({
+    postText,
+    setProcessing,
+    setMsgInfo,
+    siteurl,
+    setMediaData,
+}: {
+    postText: string
+    setProcessing: Dispatch<SetStateAction<boolean>>
+    setMsgInfo: Dispatch<SetStateAction<msgInfo>>
+    siteurl: string
+    setMediaData: Dispatch<SetStateAction<MediaData | null>>
+}) => {
+    const linkUrl = getLinkFromPostText({ postText })
+    if (linkUrl === null) return
+    setProcessing(true)
+    setMsgInfo({
+        isError: false,
+        msg: "リンクカードを取得中...",
+    })
+    try {
+        let blob: Blob | null = null
+        const ogpMeta = await getOgpMeta({
+            siteurl,
+            externalUrl: linkUrl,
+            languageCode: "ja",
+        })
+        if (ogpMeta.type === "error") {
+            const e: Error = new Error(ogpMeta.message)
+            e.name = ogpMeta.error
+            throw e
+        }
+        // titleが存在しない場合は、暫定的にTitleをURLにする
+        if (ogpMeta.title === "") {
+            ogpMeta.title = linkUrl
+        }
+        if (ogpMeta.image !== "") {
+            blob = await getOgpBlob({
+                siteurl,
+                externalUrl: ogpMeta.image,
+                languageCode: "ja",
+            })
+        }
+        setMediaData({
+            type: "external",
+            meta: {
+                ...ogpMeta,
+                url: linkUrl,
+            },
+            images: [
+                {
+                    blob,
+                },
+            ],
+        })
+        setMsgInfo({
+            isError: false,
+            msg: "リンクカードを取得しました！",
+        })
+    } catch (e: unknown) {
+        if (e instanceof Error) {
+            setMsgInfo({
+                isError: true,
+                msg: `${e.name}: ${e.message}`,
+            })
+        }
+        //リンクカード設定を解除
+        setMediaData(null)
+    }
+    setProcessing(false)
+}
+
+const getLinkFromPostText = ({
+    postText,
+}: {
+    postText: string
+}): string | null => {
+    const richTextLinkParser = new richTextFacetParser("link")
+    const parseResult = richTextLinkParser.getFacet(postText)
+    if (parseResult.length < 1) {
+        return null
+    } else {
+        // 貼られた最後のlinkからOGPを取得する
+        // いずれは任意のURLを選べるようにしたい
+        return parseResult[parseResult.length - 1]
+    }
+}
+
 export const Component = ({
     postText,
     setMediaData,
     isProcessing,
     setProcessing,
     setMsgInfo,
+    siteurl,
 }: {
     postText: string
     setMediaData: Dispatch<SetStateAction<MediaData | null>>
     isProcessing: boolean
     setProcessing: Dispatch<SetStateAction<boolean>>
     setMsgInfo: Dispatch<SetStateAction<msgInfo>>
+    siteurl: string
 }) => {
-    const siteurl = location.origin
     const linkMaxLength = 50
     const [linkUrl, setLinkUrl] = useState<string | null>(null)
-    const handleGetOGP = async () => {
-        if (linkUrl === null) return
-        setProcessing(true)
-        setMsgInfo({
-            isError: false,
-            msg: "リンクカードを取得中...",
-        })
-        try {
-            let blob: Blob | null = null
-            const ogpMeta = await getOgpMeta({
-                siteurl,
-                externalUrl: linkUrl,
-                languageCode: "ja",
-            })
-            if (ogpMeta.type === "error") {
-                const e: Error = new Error(ogpMeta.message)
-                e.name = ogpMeta.error
-                throw e
-            }
-            // titleが存在しない場合は、暫定的にTitleをURLにする
-            if (ogpMeta.title === "") {
-                ogpMeta.title = linkUrl
-            }
-            if (ogpMeta.image !== "") {
-                blob = await getOgpBlob({
-                    siteurl,
-                    externalUrl: ogpMeta.image,
-                    languageCode: "ja",
-                })
-            }
-            setMediaData({
-                type: "external",
-                meta: {
-                    ...ogpMeta,
-                    url: linkUrl,
-                },
-                images: [
-                    {
-                        blob,
-                    },
-                ],
-            })
-            setMsgInfo({
-                isError: false,
-                msg: "リンクカードを取得しました！",
-            })
-        } catch (e: unknown) {
-            if (e instanceof Error) {
-                setMsgInfo({
-                    isError: true,
-                    msg: `${e.name}: ${e.message}`,
-                })
-            }
-            //リンクカード設定を解除
-            setMediaData(null)
-        }
-        setProcessing(false)
-    }
     useEffect(() => {
-        const richTextLinkParser = new richTextFacetParser("link")
-        const parseResult = richTextLinkParser.getFacet(postText)
-        if (parseResult.length < 1) {
-            setLinkUrl(null)
-        } else {
-            // 貼られた最後のlinkからOGPを取得する
-            // いずれは任意のURLを選べるようにしたい
-            setLinkUrl(parseResult[parseResult.length - 1])
-        }
+        setLinkUrl(getLinkFromPostText({ postText }))
     }, [postText])
     return (
         <ProcButton
             buttonID="linkcardattach"
-            handler={handleGetOGP}
+            handler={() =>
+                handleGetOGP({
+                    postText,
+                    setProcessing,
+                    setMsgInfo,
+                    siteurl,
+                    setMediaData,
+                })
+            }
             isProcessing={isProcessing}
             context={
                 <>
@@ -119,3 +150,4 @@ export const Component = ({
     )
 }
 export default Component
+export { handleGetOGP }


### PR DESCRIPTION
Resolves #103 

[`share_target`](https://developer.mozilla.org/ja/docs/Web/Manifest/share_target)を用いた「Skyshareへのデータ共有」機能の実装案です。

対応している環境は実質AndroidのChromeのみです。が、内部的にはリクエストパラメータを通して投稿テキストを生成しているだけなので、やり方によっては他の環境にも応用できそうですね。