### PR TITLE
[Feature Request]: Web Share API2を用いた Xへの投稿経路の実装 #89

### DIFF
--- a/astro/src/components/Client/AppForm.tsx
+++ b/astro/src/components/Client/AppForm.tsx
@@ -22,7 +22,7 @@ const Component = ({
     setMsgInfo: Dispatch<SetStateAction<msgInfo>>
 }) => {
     // メディアのプレビューに関するStateコンストラクタ
-    const [mediaData, setMediaData] = useState<MediaData>(null)
+    const [mediaData, setMediaData] = useState<MediaData>(undefined)
     const [popupPreviewOptions, setPopupPreviewOptions] =
         useState<popupPreviewOptions>(null!)
     const Forms = ({ mode }: { mode: modes }) => {

--- a/astro/src/components/Client/bsky/MediaPreview/AltDialog.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/AltDialog.tsx
@@ -33,7 +33,7 @@ export const Component = ({
     mediaData: MediaData
 }) => {
     // mediaDataがimageではない場合はコンポーネントを無効に
-    if (mediaData === null || mediaData.type !== "images") {
+    if (typeof mediaData === "undefined" || mediaData.type !== "images") {
         return
     }
     let mediaDataItem = mediaData.images[itemId]

--- a/astro/src/components/Client/bsky/MediaPreview/DeleteItemButton.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/DeleteItemButton.tsx
@@ -17,12 +17,12 @@ const Component = ({
         if (itemId < 0 || itemId > 3) {
             return
         }
-        if (mediaData === null) {
+        if (typeof mediaData === "undefined") {
             return
         }
         if (mediaData.type === "external") {
             // linkcardは1枚なので消した時点でlistは空
-            setMediaData(null)
+            setMediaData(undefined)
             return
         }
         if (mediaData.type === "images") {
@@ -30,17 +30,21 @@ const Component = ({
                 return
             }
             // Listから自身のitemIdを取り除き、これをリストに追加する
-            const result = mediaData.images.filter(
+            const imagesResult = mediaData.images.filter(
+                (_, index) => index !== itemId,
+            )
+            const filesResult = mediaData.files.filter(
                 (_, index) => index !== itemId,
             )
             // 全てのメディアが削除された場合は null とする
-            if (result.length <= 0) {
-                setMediaData(null)
+            if (imagesResult.length <= 0) {
+                setMediaData(undefined)
                 return
             }
             setMediaData({
                 type: mediaData.type,
-                images: result,
+                images: imagesResult,
+                files: filesResult,
             })
         }
     }

--- a/astro/src/components/Client/bsky/MediaPreview/MetaView.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/MetaView.tsx
@@ -3,7 +3,7 @@ import { MediaData } from "../../common/types"
 
 export const Component = ({ mediaData }: { mediaData: MediaData }) => {
     // mediaDataがimageではない場合はコンポーネントを無効に
-    if (mediaData === null || mediaData.type !== "external") {
+    if (typeof mediaData === "undefined" || mediaData.type !== "external") {
         return
     }
     const mediaDataItem = mediaData.meta

--- a/astro/src/components/Client/bsky/MediaPreview/index.tsx
+++ b/astro/src/components/Client/bsky/MediaPreview/index.tsx
@@ -39,11 +39,13 @@ const Component = ({
         classNameImage?: string
         className?: string
     }) => {
-        const mediaBlob =
-            mediaData !== null ? mediaData.images[index].blob : null
+        const mediaBlob: Blob | undefined =
+            typeof mediaData !== "undefined"
+                ? mediaData.images[index].blob
+                : undefined
 
-        const alt =
-            mediaData !== null && mediaData.type === "images"
+        const alt: string | undefined =
+            typeof mediaData !== "undefined" && mediaData.type === "images"
                 ? mediaData.images[index].alt
                 : undefined
         return (
@@ -53,10 +55,11 @@ const Component = ({
                     mediaData={mediaData}
                     setMediaData={setMediaData}
                 />
-                {mediaData !== null && mediaData.type === "images" && (
-                    <AltDialog itemId={index} mediaData={mediaData} />
-                )}
-                {mediaBlob !== null ? (
+                {typeof mediaData !== "undefined" &&
+                    mediaData.type === "images" && (
+                        <AltDialog itemId={index} mediaData={mediaData} />
+                    )}
+                {typeof mediaBlob !== "undefined" ? (
                     <img
                         src={URL.createObjectURL(mediaBlob)}
                         alt={alt}
@@ -182,7 +185,7 @@ const Component = ({
     const [PreviewForm, setPreviewForm] = useState<ReactNode>(PreviewLayout(-1))
 
     useEffect(() => {
-        if (mediaData !== null) {
+        if (typeof mediaData !== "undefined") {
             if (mediaData.type === "external") {
                 setPreviewForm(PreviewLayout(mediaData.images !== null ? 1 : 0))
             }
@@ -197,9 +200,10 @@ const Component = ({
     return (
         <div className={["border-2", "rounded-2xl", "p-2"].join(" ")}>
             <div className="aspect-[1.91/1] relative m-0">{PreviewForm}</div>
-            {mediaData !== null && mediaData.type === "external" && (
-                <MetaView mediaData={mediaData} />
-            )}
+            {typeof mediaData !== "undefined" &&
+                mediaData.type === "external" && (
+                    <MetaView mediaData={mediaData} />
+                )}
         </div>
     )
 }

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -190,7 +190,7 @@ const Component = ({
                 msg = "Unexpected Unknown Error"
                 if (e instanceof Error) {
                     if (e.name === "AbortError") {
-                        msg = "共有を中断しました"
+                        msg = "共有が中断されたため、Blueskyにのみ投稿されました"
                     // // WebShareAPIをSafariで動かす場合、HTTPSのホストでしか利用できない成約がある
                     // } else if (e.name === "NotAllowedError") {
                     //     msg = "On Safari, localhost not allowed to use WebShareAPI with media attached."

--- a/astro/src/components/Client/bsky/PostForm.tsx
+++ b/astro/src/components/Client/bsky/PostForm.tsx
@@ -9,7 +9,8 @@ import AutoXPopupToggle from "./optionToggles/AutoXPopupToggle"
 import NoGenerateToggle from "./optionToggles/NoGenerateToggle"
 import ShowTaittsuuToggle from "./optionToggles/ShowTaittsuuToggle"
 import ForceIntentToggle from "./optionToggles/ForceIntentToggle"
-import AppendVia from "./optionToggles/AppendViaToggle"
+import AppendViaToggle from "./optionToggles/AppendViaToggle"
+import UseWebAPIToggle from "./optionToggles/UseWebAPIToggle"
 import LanguageSelectList from "./selectLists/LanguageSelectList"
 import Details from "../common/Details"
 import TagInputList from "./unique/TagInputList"
@@ -34,9 +35,9 @@ import { type msgInfo, type modes, MediaData } from "../common/types"
 const MemoMediaPreview = memo(MediaPreview)
 
 export type callbackPostOptions = {
-    postText: string
-    previewTitle: string | null
-    previewData: Blob | null
+    externalPostText: string
+    previewTitle: string | undefined
+    previewData: Blob | undefined
 }
 
 /**
@@ -92,6 +93,8 @@ const Component = ({
     const [language, setLanguage] = useState<string>("ja")
     // 下書きのstate情報
     const [drafts, setDrafts] = useState<Array<string>>([])
+    // ユーザエージェント
+    const userAgent = window.navigator.userAgent.toLowerCase()
 
     // Options
     // ポスト時に自動でXを開く
@@ -106,6 +109,12 @@ const Component = ({
     const [selfLabel, setSelfLabel] = useState<label.value | null>(null)
     // viaを付与する
     const [appendVia, setAppendVia] = useState<boolean>(false)
+    // viaを付与する
+    const [useWebAPI, setUseWebAPI] = useState<boolean>(false)
+
+    // 判定式
+    const isAutoPop = autoPop && !useWebAPI
+    const isNoGenerate = useWebAPI || noGenerate
 
     useEffect(() => {
         const handleDragOver = (e: DragEvent) => {
@@ -135,7 +144,7 @@ const Component = ({
      * 投稿リセット（下書きを削除）ボタンを押した際の動作
      */
     const handlerCancel = () => {
-        setMediaData(null)
+        setMediaData(undefined)
         setPostText("")
     }
 
@@ -143,23 +152,63 @@ const Component = ({
      * PostButtonコンポーネントのcallback関数
      * @param options callback元から取得したいオプション
      */
-    const callbackPost = (options: callbackPostOptions) => {
-        if (autoPop) {
+    const callbackPost = async (options: callbackPostOptions) => {
+        if (isAutoPop) {
             callPopup({
-                postText: options.postText,
+                postText: options.externalPostText,
                 kind: "xcom",
             })
         }
-        const mediaObjectURL: string | null = options.previewData
+        let isNeedSetMode = true
+        const mediaObjectURL: string | undefined = options.previewData
             ? URL.createObjectURL(options.previewData)
-            : null
+            : undefined
         const popupPreviewOptions: popupPreviewOptions = {
-            postText: options.postText,
+            postText: options.externalPostText,
             mediaObjectURL: mediaObjectURL,
             ogpTitle: options.previewTitle,
         }
-        setPopupPreviewOptions(popupPreviewOptions)
-        setMode("xcom")
+        if (useWebAPI) {
+            let msg: string = "共有メニューを展開中..."
+            let isError: boolean = false
+            const url = mediaData?.type === "external" ? mediaData.meta.url : ""
+            const files = mediaData?.type === "images" ? mediaData.files : []
+            try {
+                if (navigator.share !== undefined) {
+                    await navigator.share({
+                        text: options.externalPostText,
+                        url: url,
+                        files: files,
+                    })
+                    isNeedSetMode = false
+                } else {
+                    isError = true
+                    msg = "このブラウザは現在WebShareAPIに対応していません"
+                }
+                msg = "共有を完了しました"
+            } catch (e: unknown) {
+                msg = "Unexpected Unknown Error"
+                if (e instanceof Error) {
+                    if (e.name === "AbortError") {
+                        msg = "共有を中断しました"
+                    // // WebShareAPIをSafariで動かす場合、HTTPSのホストでしか利用できない成約がある
+                    // } else if (e.name === "NotAllowedError") {
+                    //     msg = "On Safari, localhost not allowed to use WebShareAPI with media attached."
+                    }else {
+                        msg = e.name + ": " + e.message
+                        isError = true
+                    }
+                }
+            }
+            setMsgInfo({
+                msg: msg,
+                isError: isError,
+            })
+        }
+        if (isNeedSetMode) {
+            setPopupPreviewOptions(popupPreviewOptions)
+            setMode("xcom")
+        }
         handlerCancel()
     }
 
@@ -169,7 +218,7 @@ const Component = ({
      */
     const isValidPost = () =>
         postText.length >= 1 ||
-        (mediaData !== null && mediaData.images.length > 0)
+        (typeof mediaData !== "undefined" && mediaData.images.length > 0)
 
     return (
         <Tweetbox>
@@ -196,7 +245,7 @@ const Component = ({
                         language={language}
                         selfLabel={selfLabel}
                         options={{
-                            noGenerateOgp: noGenerate,
+                            noGenerateOgp: isNoGenerate,
                             appendVia: appendVia,
                         }}
                         mediaData={mediaData}
@@ -205,6 +254,7 @@ const Component = ({
                         setProcessing={setProcessing}
                         setMsgInfo={setMsgInfo}
                         disabled={!isValidPost()}
+                        userAgent={userAgent}
                     />
                 </div>
             </div>
@@ -266,13 +316,20 @@ const Component = ({
                 <div className="flex flex-wrap mb-4">
                     <AutoXPopupToggle
                         labeltext={"Xを自動で開く"}
-                        prop={autoPop}
+                        prop={isAutoPop}
                         setProp={setAutoPop}
+                        isLocked={useWebAPI}
                     />
                     <NoGenerateToggle
                         labeltext={"Xへの画像は自身で添付する"}
-                        prop={noGenerate}
+                        prop={isNoGenerate}
                         setProp={setNoGenerate}
+                        isLocked={useWebAPI}
+                    />
+                    <UseWebAPIToggle
+                        labeltext={"Xではなく共有メニューを表示する(対応ブラウザのみ)"}
+                        prop={useWebAPI}
+                        setProp={setUseWebAPI}
                     />
                 </div>
             </div>
@@ -291,15 +348,17 @@ const Component = ({
                             prop={showTaittsuu}
                             setProp={setShowTaittsuu}
                         />
-                        <ForceIntentToggle
-                            labeltext={"Xの投稿はアプリを強制的に起動する"}
-                            prop={noUseXApp}
-                            setProp={setNoUseXApp}
-                        />
-                        <AppendVia
+                        <AppendViaToggle
                             labeltext={"Viaを付与する"}
                             prop={appendVia}
                             setProp={setAppendVia}
+                        />
+                        <ForceIntentToggle
+                            labeltext={
+                                "【削除予定】Xの投稿はアプリを強制的に起動する"
+                            }
+                            prop={noUseXApp}
+                            setProp={setNoUseXApp}
                         />
                     </div>
                 </Details>

--- a/astro/src/components/Client/bsky/buttons/LinkcardAttachButton.tsx
+++ b/astro/src/components/Client/bsky/buttons/LinkcardAttachButton.tsx
@@ -22,7 +22,7 @@ const handleGetOGP = async ({
     setProcessing: Dispatch<SetStateAction<boolean>>
     setMsgInfo: Dispatch<SetStateAction<msgInfo>>
     siteurl: string
-    setMediaData: Dispatch<SetStateAction<MediaData | null>>
+    setMediaData: Dispatch<SetStateAction<MediaData>>
 }) => {
     const linkUrl = getLinkFromPostText({ postText })
     if (linkUrl === null) return
@@ -32,7 +32,7 @@ const handleGetOGP = async ({
         msg: "リンクカードを取得中...",
     })
     try {
-        let blob: Blob | null = null
+        let blob: Blob | undefined = undefined
         const ogpMeta = await getOgpMeta({
             siteurl,
             externalUrl: linkUrl,
@@ -78,7 +78,7 @@ const handleGetOGP = async ({
             })
         }
         //リンクカード設定を解除
-        setMediaData(null)
+        setMediaData(undefined)
     }
     setProcessing(false)
 }
@@ -108,7 +108,7 @@ export const Component = ({
     siteurl,
 }: {
     postText: string
-    setMediaData: Dispatch<SetStateAction<MediaData | null>>
+    setMediaData: Dispatch<SetStateAction<MediaData>>
     isProcessing: boolean
     setProcessing: Dispatch<SetStateAction<boolean>>
     setMsgInfo: Dispatch<SetStateAction<msgInfo>>

--- a/astro/src/components/Client/bsky/lib/addImageMediaData.ts
+++ b/astro/src/components/Client/bsky/lib/addImageMediaData.ts
@@ -9,29 +9,33 @@ const allowedMimeTypes: string[] = ["image/png", "image/jpeg"]
 const imageExtensions: string[] = ["png", "jpeg", "jpg"]
 
 /**
- *
- * @param Blobs 追加するFile
+ * setMediaDataへ新規ファイルを差し込む処理
+ * @param Files 追加するFile
  */
 const addImageMediaData = (
-    Blobs: Array<File>,
-    MediaData: MediaData,
+    Files: Array<File>,
+    mediaData: MediaData,
     setMediaData: Dispatch<SetStateAction<MediaData>>,
 ) => {
-    if (Blobs.length <= 0) {
+    if (Files.length <= 0) {
         return
     }
     // MediaData型は毎回typeにimagesを指定して定義しなおす
     const newMediaData: MediaData = {
         type: "images",
         images:
-            MediaData !== null && MediaData.type === "images"
-                ? MediaData.images
+            typeof mediaData !== "undefined" && mediaData.type === "images"
+                ? mediaData.images
+                : [],
+        files:
+            typeof mediaData !== "undefined" && mediaData.type === "images"
+                ? mediaData.files
                 : [],
     }
     // MediaDataImagesを定義
-    const newMediaDataImages: Array<{ alt: string; blob: Blob }> = [
+    const newMediaDataImages: { alt: string; blob: Blob }[] = [
         ...newMediaData.images,
-        ...Blobs.filter(value => allowedMimeTypes.includes(value.type)).map(
+        ...Files.filter(value => allowedMimeTypes.includes(value.type)).map(
             value => {
                 return {
                     alt: "",
@@ -42,10 +46,12 @@ const addImageMediaData = (
             },
         ),
     ]
+    const newMediaDataFiles: File[] = newMediaData.files.concat(Files)
     // 結合
     const result: MediaData = {
         type: "images",
         images: newMediaDataImages.slice(0, maxAttachableImages),
+        files: newMediaDataFiles.slice(0, maxAttachableImages)
     }
     setMediaData(result)
 }

--- a/astro/src/components/Client/bsky/optionToggles/AppendViaToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/AppendViaToggle.tsx
@@ -23,6 +23,7 @@ const Component = ({
             initialValue={readAppendVia(false)}
             setPropConfig={setAppendVia}
             labeltext={labeltext}
+            isLocked={false}
         />
     )
 }

--- a/astro/src/components/Client/bsky/optionToggles/AutoXPopupToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/AutoXPopupToggle.tsx
@@ -11,10 +11,12 @@ const Component = ({
     labeltext,
     prop,
     setProp,
+    isLocked
 }: {
     labeltext: ReactNode
     prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
+    isLocked: boolean
 }) => {
     return (
         <ToggleSwitch
@@ -23,6 +25,7 @@ const Component = ({
             initialValue={readAutoXPopup(false)}
             setPropConfig={setAutoXPopup}
             labeltext={labeltext}
+            isLocked={isLocked}
         />
     )
 }

--- a/astro/src/components/Client/bsky/optionToggles/NoGenerateToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/NoGenerateToggle.tsx
@@ -11,10 +11,12 @@ const Component = ({
     labeltext,
     prop,
     setProp,
+    isLocked,
 }: {
     labeltext: ReactNode
     prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
+    isLocked: boolean
 }) => {
     return (
         <ToggleSwitch
@@ -23,6 +25,7 @@ const Component = ({
             initialValue={readNoGenerate(false)}
             setPropConfig={setNoGenerate}
             labeltext={labeltext}
+            isLocked={isLocked}
         />
     )
 }

--- a/astro/src/components/Client/bsky/optionToggles/SavePasswordToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/SavePasswordToggle.tsx
@@ -23,6 +23,7 @@ const Component = ({
             initialValue={readSavePassword(false)}
             setPropConfig={setSavePassword}
             labeltext={labeltext}
+            isLocked={false}
         />
     )
 }

--- a/astro/src/components/Client/bsky/optionToggles/ShowTaittsuuToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/ShowTaittsuuToggle.tsx
@@ -23,6 +23,7 @@ const Component = ({
             initialValue={readShowTaittsuu(false)}
             setPropConfig={setShowTaittsuu}
             labeltext={labeltext}
+            isLocked={false}
         />
     )
 }

--- a/astro/src/components/Client/bsky/optionToggles/UseWebAPIToggle.tsx
+++ b/astro/src/components/Client/bsky/optionToggles/UseWebAPIToggle.tsx
@@ -5,7 +5,7 @@ import { Dispatch, ReactNode, SetStateAction } from "react"
 import ToggleSwitch from "../../common/ToggleSwitch"
 
 // service
-import { readForceIntent, setForceIntent } from "@/utils/useLocalStorage"
+import { readUseWebShareAPI, setUseWebShareAPI } from "@/utils/useLocalStorage"
 
 const Component = ({
     labeltext,
@@ -16,13 +16,12 @@ const Component = ({
     prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
 }) => {
-    // このコンポーネントおよび関連コンポーネントはWebShareAPI採用に伴い、削除予定
     return (
         <ToggleSwitch
             prop={prop}
             setProp={setProp}
-            initialValue={readForceIntent(false)}
-            setPropConfig={setForceIntent}
+            initialValue={readUseWebShareAPI(false)}
+            setPropConfig={setUseWebShareAPI}
             labeltext={labeltext}
             isLocked={false}
         />

--- a/astro/src/components/Client/common/ToggleSwitch.tsx
+++ b/astro/src/components/Client/common/ToggleSwitch.tsx
@@ -6,12 +6,14 @@ const Component = ({
     setProp,
     initialValue,
     setPropConfig,
+    isLocked
 }: {
     labeltext: ReactNode
     prop: boolean
     setProp: Dispatch<SetStateAction<boolean>>
     initialValue: boolean
     setPropConfig: (flag: boolean) => void
+    isLocked: boolean
 }) => {
     const inputRef = useRef<HTMLInputElement>(null!)
     const handleClick = () => {
@@ -40,13 +42,14 @@ const Component = ({
                     ref={inputRef}
                     checked={prop}
                     onChange={handleCheck}
+                    disabled={isLocked}
                     type="checkbox"
                     className="peer sr-only"
                 />
                 <label className="text-sm">{labeltext}:&nbsp;</label>
                 <span
                     onClick={handleClick}
-                    className="my-auto block w-8 bg-gray-500 rounded-full p-[1px] 
+                    className="cursor-pointer my-auto block w-8 bg-gray-500 rounded-full p-[1px] 
                         after:block after:h-4 after:w-4 after:rounded-full 
                         after:bg-white after:transition 
                         peer-checked:bg-blue-500 

--- a/astro/src/components/Client/common/types.ts
+++ b/astro/src/components/Client/common/types.ts
@@ -6,13 +6,13 @@ export type msgInfo = {
     isError: boolean
 }
 
-export type MediaData = LinkCard | Images | null
+export type MediaData = LinkCard | Images | undefined
 type LinkCard = {
     type: "external"
     // 処理の便宜上 Imagesと同様にArrayとしているが
     // 実際は項目数1の配列。改善したい。
     images: Array<{
-        blob: Blob | null
+        blob: Blob | undefined
     }>
     meta: ogpMetaData & {
         url: string
@@ -20,8 +20,9 @@ type LinkCard = {
 }
 type Images = {
     type: "images"
-    images: Array<{
+    images: {
         alt: string
         blob: Blob
-    }>
+    }[]
+    files: File[]
 }

--- a/astro/src/components/Client/intents/PopupPreviewForm.tsx
+++ b/astro/src/components/Client/intents/PopupPreviewForm.tsx
@@ -38,7 +38,7 @@ export const Component = ({
                 </div>
                 {/* プレビュー画像 */}
                 <div className="block relative h-auto max-w-full">
-                    {popupPreviewOptions.mediaObjectURL !== null && (
+                    {typeof popupPreviewOptions.mediaObjectURL !== "undefined" && (
                         <>
                             {/* 画像 */}
                             {popupPreviewOptions.mediaObjectURL !== "" ? (
@@ -67,7 +67,7 @@ export const Component = ({
                                 </div>
                             )}
                             {/* 画像の左端に表示されるタイトル文字 */}
-                            {popupPreviewOptions.ogpTitle !== null && (
+                            {typeof popupPreviewOptions.ogpTitle !== "undefined" && (
                                 <div className="absolute bottom-2 left-4 bg-opacity-70 rounded-md px-2 text-white bg-black">
                                     {popupPreviewOptions.ogpTitle}
                                 </div>

--- a/astro/src/components/Client/intents/types.ts
+++ b/astro/src/components/Client/intents/types.ts
@@ -19,8 +19,8 @@ export type intentPreset = {
  * @param postText ポスト内容
  */
 export type popupPreviewOptions = {
-    mediaObjectURL: string | null
-    ogpTitle: string | null
+    mediaObjectURL: string | undefined
+    ogpTitle: string | undefined
     postText: string
 }
 

--- a/astro/src/utils/useLocalStorage.ts
+++ b/astro/src/utils/useLocalStorage.ts
@@ -17,6 +17,7 @@ const LSKeyName: Obj = {
     savedTags: "savedTags",
     drafts: "drafts",
     appendVia: "appendVia",
+    useWebShareAPI: "useWebShareAPI"
 }
 
 const ZodTags = z.array(z.string())
@@ -30,6 +31,22 @@ const ZodLoginInfo = z.object({
     pw: z.string(),
 })
 type LoginInfo = z.infer<typeof ZodLoginInfo>
+
+export const readUseWebShareAPI = (def: boolean): boolean => {
+    const value = get_ls_value(LSKeyName.useWebShareAPI)
+    if (value !== null) {
+        return value === "true"
+    }
+    rm_ls_value(LSKeyName.useWebShareAPI)
+    return def
+}
+
+export const setUseWebShareAPI = (flag: boolean): void => {
+    set_ls_value(LSKeyName.useWebShareAPI, flag.toString())
+    if (flag === false) {
+        rm_ls_value(LSKeyName.useWebShareAPI)
+    }
+}
 
 // viaはlexicon的には定義されていない?付与しての投稿自体は問題ないため、オプションに変更
 export const readAppendVia = (def: boolean): boolean => {
@@ -131,6 +148,7 @@ export const readSavePassword = (def: boolean): boolean => {
 
 export const setSavePassword = (flag: boolean): void => {
     set_ls_value(LSKeyName.savePassword, flag.toString())
+    // SavePasswordオプションがオフの場合は、ブラウザに保存したパスワードを削除する
     if (flag === false) {
         rm_ls_value(LSKeyName.loginInfo)
     }


### PR DESCRIPTION
related issue #89 

## 機能改修

`useWebAPI`トグルを用意し、共有メニューを開くか、これまで通りintentで対応するかを選択できるようになりました。
内部的には以下の3点の追加・処理変更を行いました
- `mediaData`の型更新: WebAPIで利用可能なように、`files`プロパティを追加しました。
    -  mediaData.imagesの編集箇所で同期するように変更処理をしています。
- `callbackPost`を非同期処理に変更・PostButtonのメソッドへの関数参照を非同期処理に変更しました。
    - `navigator.share`が非同期処理で`await`が必要であったためです。
- `useWebAPI`トグルの状態に合わせて他トグルの固定・処理自体の変更をするため、以下を追加しました。
    - `ToggleSwitch.tsx`に`isLock`オプションを付与しました。
      - ロックによりUIからの操作を封じます
    - 判定式の追加
      - 処理の判定を単純なトグルの状態ではなく、複数のトグル状態から導かれる式として定義・これを用いて処理の分岐を行うようにします。

## 機能と関係が薄い改修  

- userAgentを`PostForm`で取得し、UserAgentが必要なコンポーネントは親コンポーネントである`PostForm`から取得するように修正しました。
  - 各機能への動線が分かりづらいと感じたためです。一方`PostForm`が複雑化している課題があります。
- 今回対応した関連箇所の`null`を`undefined`へ置き換えました
  - 以後も、順次`null`でコーディングしていた箇所は`undefined`へ置き換える作業について実施、およびPRリクエスト内の修正を許容をしていきます。
  - 参考: [「値がない」ことを意味するものがundefinedとnullの2種類あることが混乱の元なので、どちらか一方を使うようにするほうがコーディング上の意思決定を減らせます。](https://typescriptbook.jp/reference/values-types-variables/undefined-vs-null#undefinedに統一するほうが簡単)
 